### PR TITLE
Proposal 0.0.5 — Integration Descriptor Protocol

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,6 +1,6 @@
 # LEBOSS Glossary of Terms
 
-**Version:** 0.0.4
+**Version:** 0.0.5
 **Status:** Proposal
 **Date:** 2026-03-09
 
@@ -187,6 +187,42 @@ Required fields include a unique integration identifier, the provider name, the 
 See also: *Governance Object*, *Satellite (Element 5)*
 
 Full object definition: [`standards/objects/integration-descriptor.md`](../standards/objects/integration-descriptor.md)
+
+---
+
+## Integration Deactivation
+
+The permanent, irreversible termination of an external integration's authorization within a LEBOSS-compliant system. A deactivated integration must not receive or transmit primary operational data. Deactivation takes effect immediately and cannot be reversed — if the governing entity later wishes to reconnect the same external platform, a new Integration Descriptor with a new integration identifier must be created.
+
+Upon deactivation, the linked Access Grant must be revoked if not already revoked. The Integration Descriptor itself must be retained for audit purposes.
+
+Contrast with: *Integration Suspension*
+
+See also: *Integration Descriptor*, *Integration Lifecycle*
+
+---
+
+## Integration Lifecycle
+
+The defined set of states an external integration passes through during its operational lifetime within a LEBOSS-compliant system: `registered`, `authorized`, `active`, `suspended`, and `deactivated`. State transitions are governed by the Integration Descriptor Protocol.
+
+Registration records the integration but does not confer authorization. Authorization requires a valid, linked Access Grant. An active integration must pass a five-step operational validation before each data operation. Suspension is immediate and reversible; deactivation is immediate and permanent.
+
+See also: *Integration Descriptor*, *Integration Suspension*, *Integration Deactivation*, *Grant Lifecycle*
+
+Full protocol: [`standards/leboss-integration-protocol.md`](../standards/leboss-integration-protocol.md)
+
+---
+
+## Integration Suspension
+
+The immediate, reversible halting of an external integration's data access by the governing entity. A suspended integration must not receive or transmit primary operational data. Suspension takes effect at the moment it is issued and may not be deferred.
+
+Suspension is reversible — the governing entity may reactivate a suspended integration after confirming that the linked Access Grant remains valid. If the linked Access Grant is revoked while the integration is suspended, a new grant must be issued before reactivation.
+
+Contrast with: *Integration Deactivation*
+
+See also: *Integration Lifecycle*, *Integration Descriptor*
 
 ---
 

--- a/proposals/0.0.5/proposal.md
+++ b/proposals/0.0.5/proposal.md
@@ -1,0 +1,107 @@
+# LEBOSS Proposal 0.0.5
+
+**Status:** Proposal
+**Branch:** proposal/0.0.5
+**Date:** 2026-03-09
+**Builds on:** proposal/0.0.4
+
+---
+
+## Summary
+
+This proposal introduces the **Integration Descriptor Protocol** — the lifecycle and behavioral rules that govern how external integrations operate within a LEBOSS-compliant environment.
+
+Version `0.0.3` defined the Integration Descriptor as a structured governance object recording the authorization of an external integration. Version `0.0.4` defined the Access Grant Protocol, which governs how authorization records are issued and enforced. This proposal bridges the two: it defines how integrations use authorizations, how their operational lifecycle is managed, and how the governing entity maintains control over every active integration.
+
+The goal is to make integrations **governed actors** rather than static registry entries. An Integration Descriptor that exists but carries no lifecycle rules provides no reliable boundary. With this protocol, the state of every integration is explicitly managed, immediately enforceable, and fully auditable.
+
+This proposal does not define transport mechanisms or API specifications for integration connectivity. It defines lifecycle states, state transition rules, authorization linkage, and required system behaviors.
+
+---
+
+## Motivation
+
+The `0.0.3` Integration Descriptor object answers: *what must be recorded about an authorized integration?* It does not answer:
+
+- When is an integration allowed to begin operating?
+- What must a system verify before allowing an integration to access data?
+- How does the governing entity immediately stop an integration mid-operation?
+- When an integration's Access Grant is revoked, what happens to the integration?
+- What is the difference between suspending and permanently deactivating an integration?
+
+Without defined answers, a system can hold valid Integration Descriptor objects while integrations operate outside any behavioral constraint. The Integration Descriptor Protocol closes this gap.
+
+There is also a direct dependency on the Access Grant Protocol: integrations must operate under valid Access Grants (LEBOSS-OBJ-ID requirements), and those grants are now governed by the lifecycle rules in `0.0.4`. The Integration Descriptor Protocol must align with and reference those rules, making the two protocols mutually reinforcing.
+
+---
+
+## Specification Changes
+
+| Document | Change |
+|----------|--------|
+| `standards/leboss-integration-protocol.md` | New — full lifecycle and behavioral protocol |
+| `standards/leboss-standard-0.0.2.md` | Updated — new §13 references the protocol |
+| `glossary/terms.md` | Updated — three new terms |
+
+---
+
+## Rationale
+
+### Why a separate protocol from the Access Grant Protocol?
+
+Access Grants govern authorization for any data-accessing party — service providers, internal systems, delegates, and integrations alike. The Integration Descriptor Protocol is specific to external integrations, which carry the highest data sovereignty risk in the LEBOSS reference model. Integrations have unique concerns: they connect to external systems outside the governing entity's control, they may transmit data outbound, and their suspension must be immediately enforceable even if the external provider is unaware.
+
+Combining these into a single document would obscure this distinction. Keeping them separate allows each to be precise.
+
+### Why five lifecycle states?
+
+`registered` and `authorized` are distinct because registration (the record existing) does not confer authorization (the permission to receive data). A common failure mode in integration governance is treating registration as implicit authorization. This protocol makes authorization a separate, explicit step.
+
+`suspended` and `deactivated` are distinct because suspension is reversible — a governing entity may suspend an integration pending investigation and reactivate it — while deactivation is permanent. Conflating these into a single "inactive" state loses important governance meaning.
+
+---
+
+## Backward Compatibility
+
+No existing normative rules are modified. No existing document sections are removed or rewritten.
+
+The Integration Descriptor object definition in `standards/objects/integration-descriptor.md` gains behavioral context from this protocol but is not modified structurally.
+
+---
+
+## Implementation Considerations
+
+The protocol specifies required behavioral properties. It does not specify:
+
+- How integrations authenticate to the governed system
+- API shape or connector mechanism for external platforms
+- How suspension signals are communicated to external providers
+- Storage or indexing of integration state
+
+These are implementation decisions. The requirement is that the behavioral outcome — immediate suspension effect, full audit coverage, validated authorization before every data access — is achieved, not that it is achieved through a specific mechanism.
+
+---
+
+## Deferred to 0.0.6 and Beyond
+
+- Audit Record Collection Protocol (how records are gathered, queried, and exported)
+- Grant transport and exchange mechanisms
+- Portability format specification (GAP-3)
+- Succession and Ownership Transfer Protocol (GAP-5)
+- Integration connectivity and API specifications
+
+---
+
+## Feedback Requested
+
+**1. Lifecycle state granularity**
+Are five states (`registered`, `authorized`, `active`, `suspended`, `deactivated`) the right model? Should `authorized` and `active` be collapsed, or is the distinction valuable?
+
+**2. Suspension reversibility**
+This proposal defines suspension as reversible. Are there cases where a suspension should become permanent automatically (e.g., after a defined period with no governing entity action)?
+
+**3. Grant revocation cascade**
+When an Access Grant that covers an integration is revoked, this protocol requires the integration to be suspended. Should the cascade be immediate suspension or immediate deactivation?
+
+**4. Outbound data flows**
+Should the protocol include specific rules for outbound data flows (data leaving the governed environment through a Satellite), or is the existing scope check in the Access Grant Protocol sufficient?

--- a/standards/leboss-integration-protocol.md
+++ b/standards/leboss-integration-protocol.md
@@ -1,0 +1,254 @@
+# LEBOSS Integration Descriptor Protocol
+## Local Entrepreneur Business Operating System Standards
+
+**Status:** Proposal
+**Version:** 0.0.5
+**Date:** 2026-03-09
+**Branch:** proposal/0.0.5
+**Depends on:** [standards/objects/integration-descriptor.md](objects/integration-descriptor.md), [standards/leboss-access-grant-protocol.md](leboss-access-grant-protocol.md)
+
+---
+
+> This document defines the lifecycle and behavioral rules for external integrations within a LEBOSS-compliant system. It makes integrations governed actors with explicit state, enforced authorization, and full audit coverage — rather than static registry entries.
+
+---
+
+## 1. Introduction
+
+The Integration Descriptor object (`standards/objects/integration-descriptor.md`) defines what must be recorded about an authorized external integration. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines how authorizations are issued and enforced. This protocol defines how integrations behave across their operational lifetime, and how those two prior specifications are applied specifically to the external integration context.
+
+External integrations (Satellite equivalents) are the point of greatest data sovereignty risk in the LEBOSS reference model. They represent boundaries at which primary operational data may flow to systems outside the governing entity's direct control. This risk requires not only that integrations be registered and authorized, but that their behavior be continuously governed and immediately adjustable.
+
+This protocol is:
+- **implementation-neutral** — it specifies what must happen, not how it is implemented
+- **transport-agnostic** — it does not define how integrations connect to external platforms
+- **complementary to the Access Grant Protocol** — integration authorization depends on valid Access Grants; this protocol defines the integration-specific layer on top
+
+---
+
+## 2. Relationship to Governance Objects and Rules
+
+This protocol operationalizes the following normative rules:
+
+| Rule | Addressed By |
+|------|-------------|
+| LEBOSS-ACC-5 — integrations must be explicitly authorized before receiving data | §4 Registration, §5 Authorization |
+| LEBOSS-ARCH-10 — integrations must not become unauthorized data exit paths | §6 Operational Validation |
+| LEBOSS-ARCH-11 — all data flows through integrations must be logged and auditable | §8 Audit Requirements |
+| LEBOSS-OBJ-ID-1 — Integration Descriptor must exist before data transmission | §4 Registration |
+| LEBOSS-OBJ-ID-4 — inactive integrations must not receive data | §7 Suspension and Deactivation |
+| LEBOSS-OBJ-ID-6 — all data flows must produce Audit Records | §8 Audit Requirements |
+
+---
+
+## 3. Integration Lifecycle
+
+An external integration moves through the following states during its lifetime:
+
+```
+registered → authorized → active → suspended → deactivated
+                                       ↑           ↓
+                                       └── (reactivation possible)
+```
+
+### State Definitions
+
+**`registered`**
+An Integration Descriptor has been created for the external integration. The integration is recorded in the system but has not yet been authorized to receive data.
+
+A registered integration MUST NOT receive primary operational data. Registration is not authorization.
+
+**`authorized`**
+The governing entity has reviewed the integration and issued a valid Access Grant covering its defined permissions and data scope. The integration may proceed to operational activation.
+
+An authorized integration MUST NOT yet transmit data until the system confirms activation. Authorization is the approval; activation is the operational readiness confirmation.
+
+**`active`**
+The integration is operational. It holds a valid, unexpired, unrevoked Access Grant and is permitted to send and receive data within its defined scope and permissions.
+
+Systems MUST validate the integration's authorization before each data operation (§6).
+
+**`suspended`**
+The governing entity has temporarily halted the integration's data access. Suspension takes effect immediately and completely. A suspended integration MUST NOT receive or transmit primary operational data.
+
+Suspension is reversible. The governing entity may reactivate a suspended integration, transitioning it back to `active` after re-confirming authorization.
+
+**`deactivated`**
+The integration has been permanently terminated. Deactivation is irreversible. A deactivated integration MUST NOT be reactivated. If the governing entity later wishes to reconnect the same external platform, a new Integration Descriptor with a new `integration_id` MUST be created.
+
+---
+
+## 4. Integration Registration
+
+Registration is the act of creating an Integration Descriptor for an external integration.
+
+### 4.1 Registration Requirements
+
+**LEBOSS-IDP-1**
+An Integration Descriptor MUST be created before any external integration MAY receive primary operational data. There is no grace period or provisional access during registration.
+
+**LEBOSS-IDP-2**
+At the moment of registration, all required fields defined in the Integration Descriptor object specification MUST be populated. A descriptor MUST NOT be created in a partial state.
+
+**LEBOSS-IDP-3**
+The `active` field MUST be set to `false` at registration. An integration is not active at the moment of registration.
+
+**LEBOSS-IDP-4**
+Registration MUST generate an Audit Record with `action: integration_registered`, referencing the new `integration_id`.
+
+### 4.2 Permissions at Registration
+
+The `permissions_requested` field SHOULD be populated at registration to document what the external provider requested. The `permissions_granted` field MUST remain empty or unset until authorization (§5) occurs. Systems MUST NOT treat `permissions_requested` as equivalent to `permissions_granted`.
+
+---
+
+## 5. Authorization Requirements
+
+Authorization is the explicit approval by the governing entity for an integration to receive data, formalized through the issuance of an Access Grant.
+
+### 5.1 Authorization Requirements
+
+**LEBOSS-IDP-5**
+An integration MUST NOT transition to `active` state without a linked, valid Access Grant. The `linked_grant_id` field on the Integration Descriptor MUST reference an Access Grant that is currently `active` as defined by the Access Grant Protocol.
+
+**LEBOSS-IDP-6**
+The Access Grant linked to an integration MUST define `scope` and `operations` that are equal to or narrower than the permissions recorded in the Integration Descriptor's `permissions_granted` field. An integration MUST NOT operate under a grant broader than its registered permissions.
+
+**LEBOSS-IDP-7**
+Authorization MUST be issued at the `governing_entity` or `brand_entity` level as defined in the Integration Descriptor object specification. The `authorization_level` field MUST be set at the time of authorization.
+
+**LEBOSS-IDP-8**
+Authorization MUST generate an Audit Record with `action: integration_authorized`, referencing the `integration_id` and the `grant_id` of the linked Access Grant.
+
+### 5.2 Grant Revocation Cascade
+
+If the Access Grant linked to an active integration is revoked under the Access Grant Protocol:
+
+**LEBOSS-IDP-9**
+The integration MUST be immediately suspended upon revocation of its linked Access Grant. The governing entity is not required to issue a separate suspension command — grant revocation cascades automatically to integration suspension.
+
+**LEBOSS-IDP-10**
+An integration that has been suspended due to grant revocation MUST NOT be reactivated until a new Access Grant has been issued and linked.
+
+---
+
+## 6. Operational Validation
+
+Before allowing any data operation involving an active integration, a LEBOSS-compliant system MUST perform the following validation sequence. A failure at any step MUST result in denial of the data operation.
+
+### Validation Sequence
+
+**Step 1 — Integration State Check**
+The integration MUST be in `active` state. Operations MUST be denied for integrations in any other state.
+
+**Step 2 — Descriptor Existence**
+A valid Integration Descriptor with the presented `integration_id` MUST exist in the system.
+
+**Step 3 — Grant Validity**
+The Access Grant referenced in `linked_grant_id` MUST pass all seven validation steps defined in the Access Grant Protocol (§5 of `leboss-access-grant-protocol.md`). An integration operating under an expired, revoked, or out-of-scope grant MUST be denied.
+
+**Step 4 — Operation Permission Check**
+The requested operation MUST appear in both the `permissions_granted` field of the Integration Descriptor and the `operations` field of the linked Access Grant.
+
+**Step 5 — Data Flow Direction Check**
+The direction of the data operation (inbound or outbound) MUST match an entry in the `data_flows` field of the Integration Descriptor. Outbound operations transmitting data categories not listed in `data_flows` MUST be denied.
+
+### Validation Audit
+
+**LEBOSS-IDP-11**
+Every denied data operation involving an integration MUST generate an Audit Record with `action: access_denied`, identifying the `integration_id`, the `grant_id`, and the failed validation step.
+
+**LEBOSS-IDP-12**
+Every permitted data operation MUST generate an Audit Record referencing both the `integration_id` and the `grant_id` under which the operation was authorized.
+
+---
+
+## 7. Suspension and Deactivation
+
+### 7.1 Suspension
+
+Suspension is the immediate, reversible halting of an integration's data access by the governing entity.
+
+**LEBOSS-IDP-13**
+The governing entity MUST be able to suspend any active integration at any time, without requiring justification to the integration provider.
+
+**LEBOSS-IDP-14**
+Suspension MUST take effect immediately. No data operations are permitted for a suspended integration. Systems MUST NOT defer, delay, or queue suspension.
+
+**LEBOSS-IDP-15**
+Suspension MUST generate an Audit Record with `action: integration_suspended`, referencing the `integration_id` and recording the timestamp.
+
+**LEBOSS-IDP-16**
+A suspended integration MAY be reactivated by the governing entity. Reactivation MUST confirm that the linked Access Grant remains valid. If the grant has expired or been revoked during the suspension period, a new grant MUST be issued before reactivation.
+
+**LEBOSS-IDP-17**
+Reactivation of a suspended integration MUST generate an Audit Record with `action: integration_activated`.
+
+### 7.2 Deactivation
+
+Deactivation is the permanent termination of an integration's authorization within the governed environment.
+
+**LEBOSS-IDP-18**
+The governing entity MUST be able to deactivate any integration (in any state) at any time.
+
+**LEBOSS-IDP-19**
+Deactivation MUST take effect immediately. A deactivated integration MUST NOT receive or transmit primary operational data.
+
+**LEBOSS-IDP-20**
+Deactivation MUST generate an Audit Record with `action: integration_deactivated`, referencing the `integration_id`.
+
+**LEBOSS-IDP-21**
+Upon deactivation, the linked Access Grant MUST be revoked if it has not already been revoked. A deactivated integration MUST NOT leave an active grant in place.
+
+**LEBOSS-IDP-22**
+A deactivated integration MUST NOT be reactivated. The `active` field on the Integration Descriptor MUST be set to `false` permanently. A new Integration Descriptor with a new `integration_id` MUST be created if the governing entity later wishes to reconnect the same external platform.
+
+**LEBOSS-IDP-23**
+The Integration Descriptor for a deactivated integration MUST be retained according to the retention requirements defined in the Integration Descriptor object specification. Deactivation does not permit deletion of the descriptor record.
+
+---
+
+## 8. Audit Requirements
+
+All integration lifecycle events are governed events and MUST produce Audit Records as defined in `standards/objects/audit-record.md`.
+
+### Required Audit Events
+
+| Lifecycle Event | Audit Record Action |
+|----------------|---------------------|
+| Integration registered | `integration_registered` |
+| Integration authorized | `integration_authorized` |
+| Integration activated | `integration_activated` |
+| Data operation permitted | `read` / `write` / `transform` / `export` |
+| Data operation denied | `access_denied` |
+| Integration suspended | `integration_suspended` |
+| Integration reactivated | `integration_activated` |
+| Integration deactivated | `integration_deactivated` |
+
+### Audit Record Requirements for Integration Events
+
+**LEBOSS-IDP-24**
+All Audit Records for integration lifecycle events MUST include the `integration_id` of the affected integration.
+
+**LEBOSS-IDP-25**
+All Audit Records for data operations MUST include both the `integration_id` and the `grant_id` under which the operation was authorized or denied.
+
+**LEBOSS-IDP-26**
+Audit Records for `access_denied` events MUST record which validation step (§6) failed.
+
+---
+
+## 9. Protocol Boundaries
+
+This protocol does not define:
+
+- **How integrations authenticate to the governed system** — the connector or credential mechanism is outside this specification
+- **How suspension is communicated to external providers** — the signaling mechanism for stopping an integration at the external platform is outside this specification
+- **API shape or payload format** — what data is exchanged and in what format is outside this specification
+- **Integration discovery or marketplace** — how integrations are found, installed, or offered is outside this specification
+
+These concerns will be addressed in future proposals.
+
+---
+
+*LEBOSS Integration Descriptor Protocol 0.0.5 — Open for community review and contribution.*

--- a/standards/leboss-standard-0.0.2.md
+++ b/standards/leboss-standard-0.0.2.md
@@ -62,6 +62,7 @@ These deferred items are captured in the gap register at [proposals/0.0.2/propos
 10. [Versioning](#10-versioning)
 11. [Governance Objects](#11-governance-objects)
 12. [Access Grant Protocol](#12-access-grant-protocol)
+13. [Integration Descriptor Protocol](#13-integration-descriptor-protocol)
 
 ---
 
@@ -547,4 +548,30 @@ The full protocol, including 17 normative rules (LEBOSS-AGP-1 through AGP-17) an
 
 ---
 
-*LEBOSS Standard 0.0.2 — Updated through proposal/0.0.4 — Open for community review and pull request contribution.*
+## 13. Integration Descriptor Protocol
+
+External integrations are the point of greatest data sovereignty risk in the LEBOSS reference model. The Integration Descriptor Protocol makes integrations governed actors — with explicit lifecycle state, enforced authorization, and full audit coverage.
+
+The protocol defines five lifecycle states: `registered`, `authorized`, `active`, `suspended`, and `deactivated`. Registration does not confer authorization. Authorization requires a valid, linked Access Grant. Active integrations must pass a five-step validation sequence before any data operation. Suspension is immediate and reversible; deactivation is immediate and permanent.
+
+The protocol operationalizes the following rules from this standard:
+
+| Rule | Protocol Section |
+|------|-----------------|
+| LEBOSS-ACC-5 — integrations must be explicitly authorized before receiving data | §4 Registration, §5 Authorization |
+| LEBOSS-ARCH-10 — integrations must not become unauthorized data exit paths | §6 Operational Validation |
+| LEBOSS-ARCH-11 — all data flows through integrations must be logged | §8 Audit Requirements |
+
+**Key behavioral requirements:**
+
+- An Integration Descriptor MUST exist before any external integration receives data. Registration is not authorization.
+- Integrations MUST hold a valid, linked Access Grant to transition to `active` state.
+- If an integration's linked Access Grant is revoked, the integration MUST be immediately suspended — no separate suspension command is required.
+- Suspension MUST take effect immediately. Deactivation is permanent — a new descriptor and grant are required for reconnection.
+- All lifecycle events MUST generate Audit Records including `integration_id` and, for data operations, `grant_id`.
+
+The full protocol, including 26 normative rules (LEBOSS-IDP-1 through IDP-26) and defined lifecycle state machine, is specified in [`standards/leboss-integration-protocol.md`](leboss-integration-protocol.md).
+
+---
+
+*LEBOSS Standard 0.0.2 — Updated through proposal/0.0.5 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

This proposal introduces the **Integration Descriptor Protocol** — the lifecycle and behavioral rules that govern how external integrations operate within a LEBOSS-compliant environment.

## Proposal document

`proposals/0.0.5/proposal.md`