### PR TITLE
fix(docs): post-0.0.12 editorial cleanup

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,7 +15,7 @@ LEBOSS uses semantic versioning in the form `X.Y.Z` with LEBOSS-specific meaning
 | `X` (leftmost) | **Published** | A committee- and member-ratified standard. Immutable. The canonical reference for conformant implementations. |
 
 **Examples:**
-- `0.0.11` — eleventh working draft; current pre-v0.1.0 draft
+- `0.0.12` — twelfth working draft; current pre-v0.1.0 draft
 - `0.1.0` — first Committee Vote candidate; stable for implementer review
 - `1.0.0` — first Published standard; ratified and immutable
 

--- a/governance/governance.md
+++ b/governance/governance.md
@@ -96,7 +96,7 @@ LEBOSS versions follow the pattern `X.Y.Z`, where each position has a specific m
 1.0.0  →  Members ratify; canonical standard published
 ```
 
-The current standard is the pre-v0.1.0 working draft, updated through proposal/0.0.11 — open for community contribution and pull requests.
+The current standard is the pre-v0.1.0 working draft, updated through proposal/0.0.12 — open for community contribution and pull requests.
 
 ---
 

--- a/presentations/slidev/governance.md
+++ b/presentations/slidev/governance.md
@@ -308,7 +308,7 @@ class: text-center
   <div class="text-5xl font-bold text-blue-300 mb-2">Z</div>
   <div class="text-sm font-semibold mb-2">Draft</div>
   <div class="text-xs text-gray-400">Rightmost digit. Increments with each accepted Proposal. Working drafts open to community feedback.</div>
-  <div class="mt-3 text-xs text-blue-300 font-mono">0.0.1 → 0.0.2 → 0.0.11</div>
+  <div class="mt-3 text-xs text-blue-300 font-mono">0.0.1 → 0.0.2 → 0.0.12</div>
 </div>
 
 <div class="bg-purple-900 bg-opacity-40 border border-purple-500 rounded-xl p-5 text-center">
@@ -329,7 +329,7 @@ class: text-center
 
 <div class="bg-white bg-opacity-5 rounded-lg p-4 text-sm">
   <strong class="text-gray-300">Current status:</strong>
-  <span class="text-gray-400"> LEBOSS is at <code class="text-blue-300">0.0.11</code> — a complete working draft preparing for <code class="text-purple-300">0.1.0</code>, the first Committee Vote candidate. Proposals 0.0.1 through 0.0.11 are open for community review.</span>
+  <span class="text-gray-400"> LEBOSS is at <code class="text-blue-300">0.0.12</code> — a complete working draft preparing for <code class="text-purple-300">0.1.0</code>, the first Committee Vote candidate. Proposals 0.0.1 through 0.0.12 are open for community review.</span>
 </div>
 
 </div>

--- a/standards/leboss-access-grant-protocol.md
+++ b/standards/leboss-access-grant-protocol.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.4
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.4
 **Depends on:** [standards/objects/access-grant.md](objects/access-grant.md)
 
 ---

--- a/standards/leboss-audit-protocol.md
+++ b/standards/leboss-audit-protocol.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.6
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.6
 **Depends on:** [standards/objects/audit-record.md](objects/audit-record.md), [standards/leboss-access-grant-protocol.md](leboss-access-grant-protocol.md), [standards/leboss-integration-protocol.md](leboss-integration-protocol.md)
 
 ---

--- a/standards/leboss-data-portability-protocol.md
+++ b/standards/leboss-data-portability-protocol.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.7
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.7
 **Depends on:** [standards/objects/audit-record.md](objects/audit-record.md), [standards/leboss-audit-protocol.md](leboss-audit-protocol.md)
 
 ---

--- a/standards/leboss-governance-objects.md
+++ b/standards/leboss-governance-objects.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.3
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.3
 
 ---
 

--- a/standards/leboss-integration-protocol.md
+++ b/standards/leboss-integration-protocol.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.5
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.5
 **Depends on:** [standards/objects/integration-descriptor.md](objects/integration-descriptor.md), [standards/leboss-access-grant-protocol.md](leboss-access-grant-protocol.md)
 
 ---
@@ -17,7 +16,7 @@
 
 The Integration Descriptor object (`standards/objects/integration-descriptor.md`) defines what must be recorded about an authorized external integration. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines how authorizations are issued and enforced. This protocol defines how integrations behave across their operational lifetime, and how those two prior specifications are applied specifically to the external integration context.
 
-External integrations (Satellite equivalents) are the point of greatest data sovereignty risk in the LEBOSS reference model. They represent boundaries at which primary operational data may flow to systems outside the governing entity's direct control. This risk requires not only that integrations be registered and authorized, but that their behavior be continuously governed and immediately adjustable.
+External integrations are the point of greatest data sovereignty risk in the LEBOSS reference model. They represent boundaries at which primary operational data may flow to systems outside the governing entity's direct control. This risk requires not only that integrations be registered and authorized, but that their behavior be continuously governed and immediately adjustable.
 
 This protocol is:
 - **implementation-neutral** — it specifies what must happen, not how it is implemented

--- a/standards/leboss-resource-model.md
+++ b/standards/leboss-resource-model.md
@@ -4,7 +4,6 @@
 **Status:** Proposal
 **Version:** 0.0.8
 **Date:** 2026-03-09
-**Branch:** proposal/0.0.8
 **Referenced by:** [standards/objects/access-grant.md](objects/access-grant.md), [standards/objects/audit-record.md](objects/audit-record.md), [standards/leboss-data-portability-protocol.md](leboss-data-portability-protocol.md)
 
 ---

--- a/standards/objects/access-grant.md
+++ b/standards/objects/access-grant.md
@@ -102,7 +102,7 @@ The delegation model itself is not fully specified in this version and will be a
 
 ## 6. Relationship to Other Objects
 
-- An Access Grant MAY reference an Integration Descriptor when granting access to an external integration (Satellite equivalent).
+- An Access Grant MAY reference an Integration Descriptor when granting access to an external integration.
 - Every data access event governed by an Access Grant SHOULD produce an Audit Record referencing the `grant_id`.
 
 ---

--- a/standards/objects/integration-descriptor.md
+++ b/standards/objects/integration-descriptor.md
@@ -12,7 +12,7 @@
 
 An Integration Descriptor is the structured record of an authorized external integration within a LEBOSS-compliant system.
 
-External integrations (Satellite equivalents) are the point of greatest data sovereignty risk in the LEBOSS reference model. Before any external integration MAY receive data, it MUST be explicitly authorized at the brand entity or governing entity level (LEBOSS-ACC-5). The Integration Descriptor is the object that records that authorization.
+External integrations are the point of greatest data sovereignty risk in the LEBOSS reference model. Before any external integration MAY receive data, it MUST be explicitly authorized at the brand entity or governing entity level (LEBOSS-ACC-5). The Integration Descriptor is the object that records that authorization.
 
 Without an Integration Descriptor, a connection to an external platform cannot be verified as explicitly authorized, and the requirement that all data flows through external integrations be logged and auditable (LEBOSS-ARCH-11) cannot be enforced.
 


### PR DESCRIPTION
## Summary

Three categories of minor editorial fixes following the 0.0.12 terminology stabilization pass. No normative rules or architectural definitions changed.

## Motivation

The 0.0.12 pass updated the glossary and conformance document. This follow-up corrects stale version references that still pointed to 0.0.11, removes parenthetical Satellite clarifiers that are now redundant since "external integration" is the defined canonical term, and strips the `Branch:` metadata field from protocol headers now that all proposal branches are merged.

## Specification Changes

**Version references (3 locations):**
- `governance/governance.md` body text: `proposal/0.0.11` → `proposal/0.0.12`
- `presentations/slidev/governance.md`: version ladder end and current-status sentence updated from `0.0.11` → `0.0.12`
- `RELEASES.md` example: `0.0.11 — eleventh working draft; current pre-v0.1.0 draft` → `0.0.12 — twelfth working draft; current pre-v0.1.0 draft`

**Redundant parentheticals removed (3 locations):**
- `standards/objects/integration-descriptor.md`: `External integrations (Satellite equivalents)` → `External integrations`
- `standards/leboss-integration-protocol.md`: same removal
- `standards/objects/access-grant.md`: `external integration (Satellite equivalent)` → `external integration`

**`Branch:` field removed from Schema B protocol headers (6 files):**
- `standards/leboss-governance-objects.md`, `leboss-access-grant-protocol.md`, `leboss-integration-protocol.md`, `leboss-audit-protocol.md`, `leboss-data-portability-protocol.md`, `leboss-resource-model.md`

## Impact Assessment

Editorial only. No MUST/SHOULD/MAY requirements added, removed, or modified.

## Backward Compatibility

Not applicable — no normative content changed.