### PR TITLE
fix(docs): update stale version refs and conformance terminology to 0.0.12

### DIFF
--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -6,9 +6,9 @@ This document tracks systems implementing or aligning with the LEBOSS specificat
 
 ## Implementations
 
-| Project | Description | Status | LEBOSS Version |
-|---------|-------------|--------|----------------|
-| *(none yet)* | | | |
+| Project        | Description | Status | LEBOSS Version |
+|----------------|-------------|--------|----------------|
+| *(none yet)*   | -           | -      | -              |
 
 ---
 
@@ -27,7 +27,7 @@ Include:
 
 ## Conformance
 
-Implementations claiming LEBOSS compatibility must satisfy the requirements defined in:
+Implementations claiming LEBOSS-compliant status must satisfy the requirements defined in:
 
 [standards/conformance.md](standards/conformance.md)
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The **Governing Entity** (Universe) owns all data. Every other element operates 
 | [`standards/`](standards/) | Normative specification — all MUST/SHOULD/MAY requirements |
 | [`glossary/`](glossary/) | Canonical terminology definitions |
 | [`governance/`](governance/) | Governance model — proposal lifecycle, committee roles |
-| [`proposals/`](proposals/) | Specification change history (0.0.1 → 0.0.11) |
+| [`proposals/`](proposals/) | Specification change history (0.0.1 → 0.0.12) |
 | [`presentations/`](presentations/) | Three-deck Slidev presentation portal |
 | [`charter/`](charter/) | Mission and philosophical foundation |
 

--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -257,7 +257,7 @@ See also: *Universe (Element 0)*
 
 ## Integration Descriptor
 
-A governance object that records the authorization of an external integration (Satellite equivalent) to receive data from a LEBOSS-compliant system. An Integration Descriptor must exist before any external integration may receive primary operational data.
+A governance object that records the authorization of an external integration to receive data from a LEBOSS-compliant system. An Integration Descriptor must exist before any external integration may receive primary operational data.
 
 Required fields include a unique integration identifier, the provider name, the authorizing entity, the authorization timestamp, the authorization level (governing entity or brand entity), granted permissions, and data flow descriptions.
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -227,7 +227,7 @@ The service provider MUST NOT use primary operational data for any purpose beyon
 
 ## Gaps Identified
 
-The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.11.
+The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.12.
 
 **GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4*
 The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17).
@@ -246,4 +246,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.11. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.12. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.11, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.12, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.11. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.12. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -476,7 +476,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.11.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.12.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -657,4 +657,4 @@ The full model, including 23 normative rules (LEBOSS-RM-1 through RM-23) and def
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.11 — Open for community review and pull request contribution.*
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.12 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

- **T-1** — Remove `(Satellite equivalent)` parenthetical from `glossary/terms.md` Integration Descriptor definition
- **V-1** — Update proposal range in `README.md` from `0.0.1 → 0.0.11` to `0.0.1 → 0.0.12`
- **V-2–V-5** — Update four inline version references in `standards/leboss-standard.md` to `0.0.12` (body text and footer; Schema A header unchanged)
- **V-6–V-7** — Update two inline version references in `standards/leboss-normative-rules.md` to `0.0.12` (body text and footer; Schema A header unchanged)
- **A-1** — Replace undefined term "LEBOSS compatibility" with "LEBOSS-compliant" in `IMPLEMENTATIONS.md`

## Notes

All changes are editorial only — no normative requirements added or modified. Schema A `Updated Through:` header fields are intentionally preserved as-is (per-document metadata, not inline prose).