### PR TITLE
feat(standards): enforcement responsibility (0.0.14)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 
 ---
 
@@ -239,6 +239,20 @@ See also: *Access Grant*, *Integration Descriptor*, *Audit Record*
 
 ---
 
+## Governed Action
+
+An operation performed within a LEBOSS-compliant system that is subject to normative
+requirements. Governed action categories include: data access, grant issuance, grant
+validation, grant revocation, audit record creation, and data export.
+
+Governed actions must be subject to rule enforcement at the time they occur. A governed
+action that proceeds without enforcement of applicable normative requirements is a
+conformance violation.
+
+See also: *Audit Event*, *Operational Enforcement*, *Access Grant*
+
+---
+
 ## Governing Committee
 
 See: *Committee* (defined in [governance/committee.md](../governance/committee.md))
@@ -388,6 +402,23 @@ Contrast with: *Satellite (Element 5)*
 ## Natural Satellite
 
 See: *Moon (Element 4)*
+
+---
+
+## Operational Enforcement
+
+The property of a LEBOSS-compliant system by which normative requirements are enforced
+at the time governed actions occur — not documented, stated as intent, or expressed
+as policy alone.
+
+Operational enforcement is a conformance requirement. A system that permits governed
+actions to proceed without enforcement of applicable normative requirements is
+non-conformant, regardless of its documented policies or stated architectural intent.
+
+The LEBOSS standard defines the obligation to enforce. It does not prescribe the
+architecture, mechanism, or technology by which enforcement is achieved.
+
+See also: *Governed Action*, *Conformance*, *LEBOSS-compliant*
 
 ---
 

--- a/proposals/0.0.14/proposal.md
+++ b/proposals/0.0.14/proposal.md
@@ -1,0 +1,126 @@
+# Proposal 0.0.14 — Enforcement Responsibility
+
+**Status:** Proposal
+**Branch:** proposal/0.0.14-enforcement-responsibility
+**Date:** 2026-03-21
+**Builds on:** proposal/0.0.13
+
+---
+
+## Summary
+
+The LEBOSS standard contains 40 normative rules describing what must be true of
+governed systems. No rule currently states that those requirements must be enforced
+in operation. A system can document every obligation, publish policies aligned with
+every requirement, and still permit governed actions to occur without enforcement —
+and under the current standard, no rule makes that a conformance failure.
+
+This proposal closes that gap. It establishes operational enforcement as a required
+property of LEBOSS-compliant systems, defines "governed action" and "operational
+enforcement" as formal terms, and explicitly states that enforcement failure —
+regardless of intent — is a conformance violation. It also affirms that the standard
+does not prescribe how enforcement is achieved.
+
+No protocol is expanded. No mechanism is introduced.
+
+---
+
+## Motivation
+
+The current standard defines obligations precisely. What it does not say is that those
+obligations must be upheld when governed actions occur. The gap is real: a system can:
+
+- Publish documentation stating that access grants are required
+- Have an architectural diagram showing grant validation
+- Pass a paper review of its stated policies
+- And still allow data access without grant validation in operation
+
+Under the current standard, no rule makes this a conformance failure. The rules
+describe the target state; none requires that the target state be maintained when it
+matters — at runtime.
+
+The correction is narrow: normative rules must be enforced in operation, not just
+described. This is expressed in one new conformance section (§8.6), one new minimum
+conformance requirement (conformance.md §3.7), one new non-conformance condition, and
+four new normative rules (ENF-1 through ENF-4).
+
+---
+
+## Specification Changes
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §8.6 Operational Enforcement; update §8.5 | Normative — conformance criteria |
+| `standards/leboss-normative-rules.md` | Add ENF rule group; update Summary Counts | Normative rules |
+| `standards/conformance.md` | Add §3.7; add non-conformance condition 7 | Normative — conformance requirements |
+| `glossary/terms.md` | Add "Governed Action"; add "Operational Enforcement" | Definitional |
+
+### `standards/leboss-standard.md`
+
+**§8.5 Non-Conformance** — fifth bullet added: satisfying normative requirements
+through documentation or stated intent without operational enforcement.
+
+**§8.6 Operational Enforcement** (new) — three numbered alignment criteria:
+- Item 15: normative requirements are enforced in operation; documentation is not enforcement
+- Item 16: governed actions are subject to rule enforcement at the time they occur
+- Item 17: enforcement failure is a conformance failure regardless of intent
+
+### `standards/leboss-normative-rules.md`
+
+Four new rules in ENF group:
+
+- **LEBOSS-ENF-1** — Normative requirements MUST be enforced in operation;
+  documentation MUST NOT be treated as satisfying normative requirements.
+- **LEBOSS-ENF-2** — Governed actions MUST be subject to rule enforcement at the
+  time they occur.
+- **LEBOSS-ENF-3** — Systems permitting governed actions without enforcement MUST NOT
+  claim LEBOSS alignment or compliance.
+- **LEBOSS-ENF-4** — The standard MUST NOT prescribe a specific enforcement
+  architecture, mechanism, or technology.
+
+Summary Counts: 40 → 44 rules.
+
+### `standards/conformance.md`
+
+**§3.7 Operational Enforcement** (new) — minimum conformance requirement: normative
+requirements must be enforced in operation; documentation and policy do not constitute
+enforcement; operational enforcement is required across all governed action categories.
+
+**§4 condition 7** (new) — Unenforced requirements: normative requirements satisfied
+by documentation, policy, or stated intent only, without operational enforcement.
+
+### `glossary/terms.md`
+
+- **Governed Action** — An operation subject to normative requirements; must be
+  enforced at the time it occurs.
+- **Operational Enforcement** — The property by which normative requirements are
+  enforced at the time governed actions occur; a conformance requirement; standard
+  does not prescribe the means of enforcement.
+
+---
+
+## Impact Assessment
+
+| Existing Element | Impact |
+|-----------------|--------|
+| All existing MUST/MUST NOT rules (OWN through SVC) | Unchanged |
+| Conformance tiers (aligned / compliant) | Unchanged |
+| All governance object definitions | Unchanged |
+| All protocols (AGP, IDP, ACP, DPP) | Unchanged |
+| Resource Model | Unchanged |
+
+---
+
+## Backward Compatibility
+
+This proposal adds no new behavioral requirements beyond stating that existing
+requirements must be enforced in operation. Systems that were genuinely conformant
+under the previous standard — meaning their normative obligations were actually upheld
+at runtime — are fully conformant after this proposal is applied.
+
+Systems that satisfied requirements through documentation only were not conformant
+under the intent of the standard. This proposal makes that non-conformance explicit.
+
+---
+
+*Proposal 0.0.14 — Community contribution. Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -128,6 +128,14 @@ The governing entity **MUST** be able to query the audit history to determine wh
 
 Service providers **MUST NOT** be able to suppress, modify, or selectively withhold audit records from the governing entity.
 
+### 3.7 Operational Enforcement
+
+A conformant system **MUST** enforce normative requirements in operation.
+
+Documentation of compliance, policy declarations, and stated intent do not constitute enforcement. A governed action that proceeds without enforcement of applicable normative requirements is a conformance violation, regardless of whether the failure was intentional.
+
+Operational enforcement is required across all governed action categories: data access, grant validation, grant revocation, audit record creation, and data export.
+
 ---
 
 ## 4. Non-Conformance Conditions
@@ -147,6 +155,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 6. **Secondary use without consent** — primary operational data is used for purposes beyond those covered by active access grants without explicit governing entity consent.
 
 7. **Rule redefinition** — the system redefines, overrides, or selectively applies normative LEBOSS requirements in a manner inconsistent with the published standard while claiming LEBOSS alignment or compliance (LEBOSS-SPEC-3).
+
+8. **Unenforced requirements** — normative requirements governing data access, grant validation, grant revocation, audit record creation, or data export are satisfied by documentation, policy declaration, or stated intent only, without operational enforcement (LEBOSS-ENF-1, LEBOSS-ENF-2).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -25,6 +25,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `CONT` — Continuity Rules
 - `SVC` — Service Provider Rules
 - `SPEC` — Specification Boundary Rules
+- `ENF`  — Enforcement Responsibility Rules
 
 ---
 
@@ -232,6 +233,34 @@ The LEBOSS standard does not designate any specific implementation as preferred 
 
 ---
 
+## Enforcement Responsibility Rules
+
+**LEBOSS-ENF-1**
+Normative requirements defined in this standard MUST be enforced in operation.
+Documentation of compliance, policy declarations, and stated intent MUST NOT be
+treated as satisfying normative requirements.
+*Source: §8.6*
+
+**LEBOSS-ENF-2**
+A LEBOSS-compliant system MUST ensure that governed actions — including data access,
+grant validation, grant revocation, audit record creation, and data export — are
+subject to rule enforcement at the time they occur.
+*Source: §8.6*
+
+**LEBOSS-ENF-3**
+A system MUST NOT be described as LEBOSS-aligned or LEBOSS-compliant if it permits
+governed actions to proceed without enforcement of applicable normative requirements,
+whether by design, configuration, exception, or operational failure.
+*Source: §8.6, conformance.md §4*
+
+**LEBOSS-ENF-4**
+The LEBOSS standard MUST NOT prescribe a specific enforcement architecture, mechanism,
+or technology. The obligation to enforce normative requirements does not constrain the
+means by which enforcement is achieved.
+*Source: §1.2, §8.6*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -241,9 +270,10 @@ The LEBOSS standard does not designate any specific implementation as preferred 
 | Architectural (ARCH) | 11 | 9 | 2 | — | — |
 | Security (SEC) | 5 | 4 | 1 | 1 | — |
 | Continuity (CONT) | 4 | 4 | 1 | — | — |
-| Service Provider (SVC) | 7 | 5 | 2 | — | — |
-| Specification Boundary (SPEC) | 4 | 2 | 2 | 1 | — |
-| **Total** | **44** | **32** | **12** | **5** | **—** |
+| Service Provider (SVC)           | 7 | 5 | 2 | — | — |
+| Specification Boundary (SPEC)    | 4 | 2 | 2 | 1 | — |
+| Enforcement Responsibility (ENF) | 4 | 2 | 3 | — | — |
+| **Total**                        | **48** | **34** | **15** | **5** | **—** |
 
 ---
 

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -480,10 +480,17 @@ A system **MUST NOT** be described as LEBOSS-aligned if it:
 - Does not support data export by the governing entity
 - Allows external integrations to receive data without explicit authorization
 - Lacks auditable records of data access
+- Satisfies normative requirements through documentation or stated intent without operational enforcement
 
 For the complete conformance definition — including minimum requirements, non-conformance conditions, and future certification scope — see [conformance.md](conformance.md).
 
 Formal conformance certification criteria will be defined in a subsequent version of the standard.
+
+### 8.6 Operational Enforcement
+
+15. Normative requirements are enforced in operation. Documentation, policy declarations, and stated intent do not constitute enforcement.
+16. Governed actions — including data access, grant validation, grant revocation, audit record creation, and data export — are subject to rule enforcement at the time they occur.
+17. A failure to operationally enforce any ownership, access, audit, revocation, or portability requirement constitutes a conformance failure, regardless of whether that failure was intentional.
 
 ---
 


### PR DESCRIPTION
## Summary

Formalizes that LEBOSS normative requirements must be enforced in operation. Documentation, policy declarations, and stated intent do not constitute enforcement. Enforcement failure is a conformance violation regardless of intent.

This is a conformance-strengthening clarification. No protocol is expanded. No enforcement mechanism or architecture is introduced. The standard does not prescribe how enforcement is achieved — only that it must be.

## Changes

- `standards/leboss-standard.md` — §8.6 Operational Enforcement (alignment criteria 15–17); §8.5 fifth non-conformance bullet
- `standards/leboss-normative-rules.md` — ENF rule group (LEBOSS-ENF-1 through ENF-4); Summary Counts 40 → 44
- `standards/conformance.md` — §3.7 Operational Enforcement (minimum requirement); §4 condition 7 (Unenforced requirements)
- `glossary/terms.md` — "Governed Action"; "Operational Enforcement"
- `proposals/0.0.14/proposal.md` — Proposal document

## Validation

- [x] Started from master
- [x] No implementation-specific terminology included
- [x] No enforcement mechanism introduced
- [x] No protocol expansion beyond enforcement clarification
- [x] Scope is minimal and atomic
- [x] Builds on 0.0.13 without modifying it