### PR TITLE
feat(standards): formalize audit as system of record (0.0.15)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 
 ---
 
@@ -239,6 +239,20 @@ See also: *Access Grant*, *Integration Descriptor*, *Audit Record*
 
 ---
 
+## Governed Action
+
+An operation performed within a LEBOSS-compliant system that is subject to normative
+requirements. Governed action categories include: data access, grant issuance, grant
+validation, grant revocation, audit record creation, and data export.
+
+Governed actions must be subject to rule enforcement at the time they occur. A governed
+action that proceeds without enforcement of applicable normative requirements is a
+conformance violation.
+
+See also: *Audit Event*, *Operational Enforcement*, *Access Grant*
+
+---
+
 ## Governing Committee
 
 See: *Committee* (defined in [governance/committee.md](../governance/committee.md))
@@ -388,6 +402,23 @@ Contrast with: *Satellite (Element 5)*
 ## Natural Satellite
 
 See: *Moon (Element 4)*
+
+---
+
+## Operational Enforcement
+
+The property of a LEBOSS-compliant system by which normative requirements are enforced
+at the time governed actions occur — not documented, stated as intent, or expressed
+as policy alone.
+
+Operational enforcement is a conformance requirement. A system that permits governed
+actions to proceed without enforcement of applicable normative requirements is
+non-conformant, regardless of its documented policies or stated architectural intent.
+
+The LEBOSS standard defines the obligation to enforce. It does not prescribe the
+architecture, mechanism, or technology by which enforcement is achieved.
+
+See also: *Governed Action*, *Conformance*, *LEBOSS-compliant*
 
 ---
 

--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.14
+**Updated Through:** proposal/0.0.15
 
 ---
 
@@ -88,6 +88,18 @@ Full retention rules: [`standards/leboss-audit-protocol.md`](../standards/leboss
 The complete set of Audit Records for a governed environment. A complete, tamper-evident record of all operations performed on data within a LEBOSS-compliant system, including who performed the operation, what operation was performed, what data was affected, and when the operation occurred.
 
 The Audit Trail is the mechanism by which data ownership is made verifiable rather than merely asserted.
+
+---
+
+## Audit as System of Record
+
+The LEBOSS principle that the set of Audit Records for a governed environment constitutes the authoritative record of all governed actions performed within that environment. The Audit Record history is not supplementary evidence — it is the canonical source of truth about what actions occurred on governed resources.
+
+A conformant system must not represent the state of a governed resource in a manner that is irreconcilable with the Audit Record history for that resource. The LEBOSS standard does not prescribe how this consistency guarantee is implemented; it requires only that the guarantee holds.
+
+Normative rules: LEBOSS-REC-1 through REC-4.
+
+See also: *Audit Record*, *Audit Trail*, *Irreconcilable State*, *Governed Action*
 
 ---
 
@@ -314,6 +326,18 @@ Suspension is reversible — the governing entity may reactivate a suspended int
 Contrast with: *Integration Deactivation*
 
 See also: *Integration Lifecycle*, *Integration Descriptor*
+
+---
+
+## Irreconcilable State
+
+A condition in which the represented state of a governed resource within a LEBOSS-compliant system cannot be reconciled with the Audit Record history for that resource. Irreconcilable state is a non-conformance condition under the LEBOSS standard (LEBOSS-REC-2).
+
+A state and its Audit Record history are irreconcilable when the history does not account for how the state came to exist — that is, when no sequence of governed actions in the Audit Record can explain the current state of the resource.
+
+The LEBOSS standard does not prescribe how systems detect or prevent irreconcilable state. It requires only that the condition not exist.
+
+See also: *Audit as System of Record*, *Audit Record*, *Governed Action*
 
 ---
 
@@ -559,6 +583,14 @@ A Star cannot function without a Planet to support it. Without a Star, a Planet 
 ## Steward
 
 A party who holds and manages data or a system on behalf of its rightful owner, bound by an obligation to act in the owner's interest. Under LEBOSS, all service providers are stewards. Being a steward does not confer ownership.
+
+---
+
+## System of Record
+
+The authoritative source of truth about governed actions in a LEBOSS-compliant environment. Under LEBOSS, the set of Audit Records constitutes the system of record for governed actions. The system of record is not a supplementary log — it is the canonical representation of what occurred.
+
+See also: *Audit as System of Record*, *Audit Record*, *Audit Trail*
 
 ---
 

--- a/proposals/0.0.14/proposal.md
+++ b/proposals/0.0.14/proposal.md
@@ -1,0 +1,126 @@
+# Proposal 0.0.14 — Enforcement Responsibility
+
+**Status:** Proposal
+**Branch:** proposal/0.0.14-enforcement-responsibility
+**Date:** 2026-03-21
+**Builds on:** proposal/0.0.13
+
+---
+
+## Summary
+
+The LEBOSS standard contains 40 normative rules describing what must be true of
+governed systems. No rule currently states that those requirements must be enforced
+in operation. A system can document every obligation, publish policies aligned with
+every requirement, and still permit governed actions to occur without enforcement —
+and under the current standard, no rule makes that a conformance failure.
+
+This proposal closes that gap. It establishes operational enforcement as a required
+property of LEBOSS-compliant systems, defines "governed action" and "operational
+enforcement" as formal terms, and explicitly states that enforcement failure —
+regardless of intent — is a conformance violation. It also affirms that the standard
+does not prescribe how enforcement is achieved.
+
+No protocol is expanded. No mechanism is introduced.
+
+---
+
+## Motivation
+
+The current standard defines obligations precisely. What it does not say is that those
+obligations must be upheld when governed actions occur. The gap is real: a system can:
+
+- Publish documentation stating that access grants are required
+- Have an architectural diagram showing grant validation
+- Pass a paper review of its stated policies
+- And still allow data access without grant validation in operation
+
+Under the current standard, no rule makes this a conformance failure. The rules
+describe the target state; none requires that the target state be maintained when it
+matters — at runtime.
+
+The correction is narrow: normative rules must be enforced in operation, not just
+described. This is expressed in one new conformance section (§8.6), one new minimum
+conformance requirement (conformance.md §3.7), one new non-conformance condition, and
+four new normative rules (ENF-1 through ENF-4).
+
+---
+
+## Specification Changes
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §8.6 Operational Enforcement; update §8.5 | Normative — conformance criteria |
+| `standards/leboss-normative-rules.md` | Add ENF rule group; update Summary Counts | Normative rules |
+| `standards/conformance.md` | Add §3.7; add non-conformance condition 7 | Normative — conformance requirements |
+| `glossary/terms.md` | Add "Governed Action"; add "Operational Enforcement" | Definitional |
+
+### `standards/leboss-standard.md`
+
+**§8.5 Non-Conformance** — fifth bullet added: satisfying normative requirements
+through documentation or stated intent without operational enforcement.
+
+**§8.6 Operational Enforcement** (new) — three numbered alignment criteria:
+- Item 15: normative requirements are enforced in operation; documentation is not enforcement
+- Item 16: governed actions are subject to rule enforcement at the time they occur
+- Item 17: enforcement failure is a conformance failure regardless of intent
+
+### `standards/leboss-normative-rules.md`
+
+Four new rules in ENF group:
+
+- **LEBOSS-ENF-1** — Normative requirements MUST be enforced in operation;
+  documentation MUST NOT be treated as satisfying normative requirements.
+- **LEBOSS-ENF-2** — Governed actions MUST be subject to rule enforcement at the
+  time they occur.
+- **LEBOSS-ENF-3** — Systems permitting governed actions without enforcement MUST NOT
+  claim LEBOSS alignment or compliance.
+- **LEBOSS-ENF-4** — The standard MUST NOT prescribe a specific enforcement
+  architecture, mechanism, or technology.
+
+Summary Counts: 40 → 44 rules.
+
+### `standards/conformance.md`
+
+**§3.7 Operational Enforcement** (new) — minimum conformance requirement: normative
+requirements must be enforced in operation; documentation and policy do not constitute
+enforcement; operational enforcement is required across all governed action categories.
+
+**§4 condition 7** (new) — Unenforced requirements: normative requirements satisfied
+by documentation, policy, or stated intent only, without operational enforcement.
+
+### `glossary/terms.md`
+
+- **Governed Action** — An operation subject to normative requirements; must be
+  enforced at the time it occurs.
+- **Operational Enforcement** — The property by which normative requirements are
+  enforced at the time governed actions occur; a conformance requirement; standard
+  does not prescribe the means of enforcement.
+
+---
+
+## Impact Assessment
+
+| Existing Element | Impact |
+|-----------------|--------|
+| All existing MUST/MUST NOT rules (OWN through SVC) | Unchanged |
+| Conformance tiers (aligned / compliant) | Unchanged |
+| All governance object definitions | Unchanged |
+| All protocols (AGP, IDP, ACP, DPP) | Unchanged |
+| Resource Model | Unchanged |
+
+---
+
+## Backward Compatibility
+
+This proposal adds no new behavioral requirements beyond stating that existing
+requirements must be enforced in operation. Systems that were genuinely conformant
+under the previous standard — meaning their normative obligations were actually upheld
+at runtime — are fully conformant after this proposal is applied.
+
+Systems that satisfied requirements through documentation only were not conformant
+under the intent of the standard. This proposal makes that non-conformance explicit.
+
+---
+
+*Proposal 0.0.14 — Community contribution. Open for committee review.*

--- a/proposals/0.0.15/proposal.md
+++ b/proposals/0.0.15/proposal.md
@@ -1,0 +1,91 @@
+# Proposal 0.0.15 — Audit as System of Record
+
+**Status:** Draft
+**Target Version:** 0.0.15
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal formalizes that Audit Records are not merely required logs — they are the **authoritative system of record** for governed actions within a LEBOSS-compliant environment. The history of governed actions is the canonical source of truth. A system must not represent a state of a governed resource that cannot be reconciled with its Audit Record history. Audit is not auxiliary to system integrity — it is foundational.
+
+---
+
+## Motivation
+
+The LEBOSS standard already requires that Audit Records be created, retained, and made accessible. Existing rules (LEBOSS-SEC-3, LEBOSS-SVC-3, LEBOSS-SVC-4) establish that audit records must exist and be available.
+
+What the standard has not established is the **authority** of those records. The standard defines audit as a requirement but not as the source of truth. As a result:
+
+1. A system can satisfy audit requirements by recording events while maintaining separate primary state that is never verified against the audit history.
+2. Nothing prevents a system from representing resource state that contradicts its audit records.
+3. The Audit Trail is defined as "the mechanism by which data ownership is made verifiable" — but the standard never declares that the audit is the authoritative record rather than one record among several.
+
+This proposal closes that gap without prescribing any implementation mechanism.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Add §8.6 Audit as System of Record
+
+Adds a new conformance section establishing the authoritative status of audit records:
+
+- The Audit Record set is the authoritative representation of governed actions
+- A system MUST NOT represent resource state irreconcilable with Audit Record history
+- Audit is foundational, not supplementary
+- No storage or processing prescription — consistency guarantee only
+
+### 2. `standards/leboss-normative-rules.md` — Add REC rule group
+
+Adds `REC` (Audit as System of Record) to the rule numbering registry with four rules:
+
+- **LEBOSS-REC-1**: Audit Records MUST constitute the authoritative record of governed actions
+- **LEBOSS-REC-2**: A system MUST NOT represent resource state irreconcilable with Audit Record history
+- **LEBOSS-REC-3**: Audit Records MUST be treated as foundational to system integrity
+- **LEBOSS-REC-4**: The standard MUST NOT prescribe how the system of record is stored or processed
+
+Rule count: 44 → 48.
+
+### 3. `standards/conformance.md` — Strengthen §3.4 and add condition 8
+
+- §3.4 Audit Records: adds declaration of authoritative status; adds explicit requirement against irreconcilable state
+- Non-conformance condition 8: **Irreconcilable state** (LEBOSS-REC-2)
+
+### 4. `glossary/terms.md` — Add three new entries
+
+- **Audit as System of Record** — the principle and its normative scope
+- **Irreconcilable State** — the prohibited condition, with precise definition
+- **System of Record** — implementation-neutral definition of authoritative record
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §8.6 Audit as System of Record | Normative addition — 3 new requirements |
+| `standards/leboss-normative-rules.md` | Add REC group (4 rules) | Normative addition — rule count 44 → 48 |
+| `standards/conformance.md` | Strengthen §3.4; add condition 8 | Normative addition — new non-conformance condition |
+| `glossary/terms.md` | Add 3 new entries | Clarification — no new requirements |
+
+---
+
+## Backward Compatibility
+
+Existing LEBOSS-aligned or LEBOSS-compliant systems that already maintain consistent audit records are unaffected. The new requirements formalize what a well-functioning audit system already guarantees: that the audit record and the system state agree.
+
+A system that previously satisfied audit requirements through record creation but maintained state independently of those records may now fail conformance under LEBOSS-REC-2. This is intentional — the proposal elevates the audit requirement from "records exist" to "records are authoritative."
+
+---
+
+## Sequence Context
+
+- 0.0.13 — defined the specification/implementation boundary
+- 0.0.14 — required that normative requirements be operationally enforced
+- 0.0.15 — established audit records as the authoritative system of record
+
+---
+
+*Proposal 0.0.15 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.14
+**Updated Through:** proposal/0.0.15
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -101,6 +101,8 @@ Operations that do not correspond to an active access grant **MUST NOT** be perm
 
 A conformant system **MUST** record an audit event for every operation that affects governed resources.
 
+The set of Audit Records for a governed environment constitutes the **authoritative record** of governed actions within that system. Audit Records are not supplementary — they are foundational to system integrity.
+
 Audit records **MUST** include:
 
 - a timestamp
@@ -109,6 +111,8 @@ Audit records **MUST** include:
 - the operation type
 
 Audit records **MUST NOT** be modifiable or deletable by actors other than the governing entity acting under documented retention policy.
+
+A conformant system **MUST NOT** represent the state of a governed resource in a manner that is irreconcilable with the Audit Record history for that resource (LEBOSS-REC-2).
 
 ### 3.5 Data Portability
 
@@ -157,6 +161,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 7. **Rule redefinition** — the system redefines, overrides, or selectively applies normative LEBOSS requirements in a manner inconsistent with the published standard while claiming LEBOSS alignment or compliance (LEBOSS-SPEC-3).
 
 8. **Unenforced requirements** — normative requirements governing data access, grant validation, grant revocation, audit record creation, or data export are satisfied by documentation, policy declaration, or stated intent only, without operational enforcement (LEBOSS-ENF-1, LEBOSS-ENF-2).
+
+9. **Irreconcilable state** — the system represents the state of a governed resource in a manner that cannot be reconciled with the Audit Record history for that resource (LEBOSS-REC-2).
 
 ---
 

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -128,6 +128,14 @@ The governing entity **MUST** be able to query the audit history to determine wh
 
 Service providers **MUST NOT** be able to suppress, modify, or selectively withhold audit records from the governing entity.
 
+### 3.7 Operational Enforcement
+
+A conformant system **MUST** enforce normative requirements in operation.
+
+Documentation of compliance, policy declarations, and stated intent do not constitute enforcement. A governed action that proceeds without enforcement of applicable normative requirements is a conformance violation, regardless of whether the failure was intentional.
+
+Operational enforcement is required across all governed action categories: data access, grant validation, grant revocation, audit record creation, and data export.
+
 ---
 
 ## 4. Non-Conformance Conditions
@@ -147,6 +155,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 6. **Secondary use without consent** — primary operational data is used for purposes beyond those covered by active access grants without explicit governing entity consent.
 
 7. **Rule redefinition** — the system redefines, overrides, or selectively applies normative LEBOSS requirements in a manner inconsistent with the published standard while claiming LEBOSS alignment or compliance (LEBOSS-SPEC-3).
+
+8. **Unenforced requirements** — normative requirements governing data access, grant validation, grant revocation, audit record creation, or data export are satisfied by documentation, policy declaration, or stated intent only, without operational enforcement (LEBOSS-ENF-1, LEBOSS-ENF-2).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -25,6 +25,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `CONT` — Continuity Rules
 - `SVC` — Service Provider Rules
 - `SPEC` — Specification Boundary Rules
+- `ENF`  — Enforcement Responsibility Rules
 
 ---
 
@@ -232,6 +233,34 @@ The LEBOSS standard does not designate any specific implementation as preferred 
 
 ---
 
+## Enforcement Responsibility Rules
+
+**LEBOSS-ENF-1**
+Normative requirements defined in this standard MUST be enforced in operation.
+Documentation of compliance, policy declarations, and stated intent MUST NOT be
+treated as satisfying normative requirements.
+*Source: §8.6*
+
+**LEBOSS-ENF-2**
+A LEBOSS-compliant system MUST ensure that governed actions — including data access,
+grant validation, grant revocation, audit record creation, and data export — are
+subject to rule enforcement at the time they occur.
+*Source: §8.6*
+
+**LEBOSS-ENF-3**
+A system MUST NOT be described as LEBOSS-aligned or LEBOSS-compliant if it permits
+governed actions to proceed without enforcement of applicable normative requirements,
+whether by design, configuration, exception, or operational failure.
+*Source: §8.6, conformance.md §4*
+
+**LEBOSS-ENF-4**
+The LEBOSS standard MUST NOT prescribe a specific enforcement architecture, mechanism,
+or technology. The obligation to enforce normative requirements does not constrain the
+means by which enforcement is achieved.
+*Source: §1.2, §8.6*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -241,9 +270,10 @@ The LEBOSS standard does not designate any specific implementation as preferred 
 | Architectural (ARCH) | 11 | 9 | 2 | — | — |
 | Security (SEC) | 5 | 4 | 1 | 1 | — |
 | Continuity (CONT) | 4 | 4 | 1 | — | — |
-| Service Provider (SVC) | 7 | 5 | 2 | — | — |
-| Specification Boundary (SPEC) | 4 | 2 | 2 | 1 | — |
-| **Total** | **44** | **32** | **12** | **5** | **—** |
+| Service Provider (SVC)           | 7 | 5 | 2 | — | — |
+| Specification Boundary (SPEC)    | 4 | 2 | 2 | 1 | — |
+| Enforcement Responsibility (ENF) | 4 | 2 | 3 | — | — |
+| **Total**                        | **48** | **34** | **15** | **5** | **—** |
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.14
+**Updated Through:** proposal/0.0.15
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -25,7 +25,8 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `CONT` — Continuity Rules
 - `SVC` — Service Provider Rules
 - `SPEC` — Specification Boundary Rules
-- `ENF`  — Enforcement Responsibility Rules
+- `ENF` — Enforcement Responsibility Rules
+- `REC` — Audit as System of Record Rules
 
 ---
 
@@ -261,6 +262,26 @@ means by which enforcement is achieved.
 
 ---
 
+## Audit as System of Record Rules
+
+**LEBOSS-REC-1**
+The set of Audit Records for a governed environment MUST constitute the authoritative record of governed actions within that environment.
+*Source: §8.7*
+
+**LEBOSS-REC-2**
+A LEBOSS-compliant system MUST NOT represent the state of a governed resource in a manner that is irreconcilable with the Audit Record history for that resource.
+*Source: §8.7*
+
+**LEBOSS-REC-3**
+Audit Records MUST be treated as foundational to system integrity. A system that treats audit records as supplementary or secondary to its primary state mechanism does not satisfy LEBOSS audit requirements.
+*Source: §8.7*
+
+**LEBOSS-REC-4**
+The LEBOSS standard MUST NOT prescribe how the system of record is stored or processed. Only the consistency guarantee between Audit Record history and represented resource state is normative.
+*Source: §8.7*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -270,10 +291,11 @@ means by which enforcement is achieved.
 | Architectural (ARCH) | 11 | 9 | 2 | — | — |
 | Security (SEC) | 5 | 4 | 1 | 1 | — |
 | Continuity (CONT) | 4 | 4 | 1 | — | — |
-| Service Provider (SVC)           | 7 | 5 | 2 | — | — |
-| Specification Boundary (SPEC)    | 4 | 2 | 2 | 1 | — |
-| Enforcement Responsibility (ENF) | 4 | 2 | 3 | — | — |
-| **Total**                        | **48** | **34** | **15** | **5** | **—** |
+| Service Provider (SVC)              | 7  | 5  | 2  | — | — |
+| Specification Boundary (SPEC)       | 4  | 2  | 2  | 1 | — |
+| Enforcement Responsibility (ENF)    | 4  | 2  | 3  | — | — |
+| Audit as System of Record (REC)     | 4  | 2  | 2  | — | — |
+| **Total**                           | **52** | **36** | **17** | **5** | **—** |
 
 ---
 

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.13
+**Updated Through:** proposal/0.0.14
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -480,10 +480,17 @@ A system **MUST NOT** be described as LEBOSS-aligned if it:
 - Does not support data export by the governing entity
 - Allows external integrations to receive data without explicit authorization
 - Lacks auditable records of data access
+- Satisfies normative requirements through documentation or stated intent without operational enforcement
 
 For the complete conformance definition — including minimum requirements, non-conformance conditions, and future certification scope — see [conformance.md](conformance.md).
 
 Formal conformance certification criteria will be defined in a subsequent version of the standard.
+
+### 8.6 Operational Enforcement
+
+15. Normative requirements are enforced in operation. Documentation, policy declarations, and stated intent do not constitute enforcement.
+16. Governed actions — including data access, grant validation, grant revocation, audit record creation, and data export — are subject to rule enforcement at the time they occur.
+17. A failure to operationally enforce any ownership, access, audit, revocation, or portability requirement constitutes a conformance failure, regardless of whether that failure was intentional.
 
 ---
 

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.14
+**Updated Through:** proposal/0.0.15
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -492,6 +492,16 @@ Formal conformance certification criteria will be defined in a subsequent versio
 16. Governed actions — including data access, grant validation, grant revocation, audit record creation, and data export — are subject to rule enforcement at the time they occur.
 17. A failure to operationally enforce any ownership, access, audit, revocation, or portability requirement constitutes a conformance failure, regardless of whether that failure was intentional.
 
+### 8.7 Audit as System of Record
+
+The set of Audit Records for a governed environment constitutes the authoritative record of all governed actions performed within that environment.
+
+18. The sequence of Audit Records **MUST** be treated as the authoritative representation of what governed actions have occurred within the governed environment.
+19. A system **MUST NOT** represent the state of a governed resource in a manner that is irreconcilable with the Audit Record history for that resource.
+20. Audit Records are not supplementary to system integrity — they are foundational. A system that treats audit records as secondary to its primary state mechanism does not satisfy LEBOSS audit requirements.
+
+The LEBOSS standard does not prescribe how the system of record is stored or processed. It requires only that the Audit Record history and the system's represented state of governed resources remain reconcilable.
+
 ---
 
 ## 9. Relationship to Other Standards
@@ -691,4 +701,4 @@ The full model, including 23 normative rules (LEBOSS-RM-1 through RM-23) and def
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.12 — Open for community review and pull request contribution.*
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.15 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Formalizes that Audit Records are not merely required logs — they are the **authoritative system of record** for governed actions within a LEBOSS-compliant environment. The history of governed actions is the canonical source of truth. A system must not represent a state of a governed resource that cannot be reconciled with its Audit Record history.

## Motivation

The standard required audit records to exist and be accessible, but never declared them authoritative. A system could satisfy audit requirements while maintaining separate state that was never verified against the audit history. This proposal closes that gap without prescribing any implementation mechanism.

## Changes

- `standards/leboss-standard.md` — new §8.6 Audit as System of Record (3 normative requirements)
- `standards/leboss-normative-rules.md` — new `REC` rule group, LEBOSS-REC-1 through REC-4; rule count 44 → 48
- `standards/conformance.md` — §3.4 strengthened with authoritative status declaration; new non-conformance condition 8 (irreconcilable state)
- `glossary/terms.md` — new entries: Audit as System of Record, Irreconcilable State, System of Record

## Nature

Normative addition. No existing rules changed. Four new REC rules added.

## Sequence

- 0.0.13 — specification/implementation boundary
- 0.0.14 — operational enforcement of normative requirements
- 0.0.15 — audit records as the authoritative system of record