### PR TITLE
feat(standards): define canonical data portability requirements (0.0.16)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.15
+**Updated Through:** proposal/0.0.16
 
 ---
 
@@ -455,6 +455,40 @@ An Operational Data Export is initiated exclusively by the governing entity or a
 See also: *Data Portability*, *Environment Migration*, *Audit Record*, *Access Grant*
 
 Full protocol: [`standards/leboss-data-portability-protocol.md`](../standards/leboss-data-portability-protocol.md)
+
+---
+
+## Complete Export
+
+A data export that satisfies the LEBOSS completeness requirement: it includes all primary operational data, all governance objects (Access Grants and Integration Descriptors), and all Audit Records within the system's retention window, with no governed resource category omitted without explicit governing entity authorization.
+
+Completeness is a normative requirement, not a best-effort goal. An export that omits any governed resource category without authorization is a non-conformance condition regardless of the reason for the omission.
+
+Normative rules: LEBOSS-PORT-1, LEBOSS-PORT-2.
+
+See also: *Operational Data Export*, *Export Manifest*, *Reconstructable Export*
+
+---
+
+## Export Manifest
+
+A structured artifact included with every data export in a LEBOSS-compliant system that identifies the scope of the export: the resource categories included, the time range covered, and the record counts for each category. The manifest enables the governing entity to verify export completeness independently, without requiring access to the source system or cooperation from the service provider.
+
+Normative rule: LEBOSS-PORT-6.
+
+See also: *Complete Export*, *Operational Data Export*, *Data Portability*
+
+---
+
+## Reconstructable Export
+
+A data export that is sufficient to rebuild the governed environment's operational state in an independent system without reliance on the exporting system, its service providers, or proprietary infrastructure. Reconstructability requires that the export include all resources, their relationships, and all governance and audit history needed to establish the state of the environment at the time of export.
+
+An export that requires vendor assistance, proprietary tools, or access to the source system in order to be used is not reconstructable and does not satisfy LEBOSS portability requirements.
+
+Normative rules: LEBOSS-PORT-3, LEBOSS-PORT-4, LEBOSS-PORT-5.
+
+See also: *Complete Export*, *Export Manifest*, *Data Portability*, *Environment Migration*
 
 ---
 

--- a/proposals/0.0.16/proposal.md
+++ b/proposals/0.0.16/proposal.md
@@ -1,0 +1,101 @@
+# Proposal 0.0.16 — Data Portability Format Requirements
+
+**Status:** Draft
+**Target Version:** 0.0.16
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal formalizes what constitutes a **valid, portable, and interoperable export** in a LEBOSS-compliant system. The standard already requires that exports exist and be machine-readable. What it has not specified is what makes an export *sufficient* — complete enough to reconstruct the governed environment elsewhere, relationship-preserving, independent of proprietary tooling, and verifiable by the governing entity without vendor involvement.
+
+This proposal closes that gap at the standard level, without prescribing any specific format, schema, or transport mechanism.
+
+---
+
+## Motivation
+
+The LEBOSS standard establishes data portability as a normative requirement (§6.4, LEBOSS-OWN-3, LEBOSS-SVC-1). The Data Portability Protocol (`leboss-data-portability-protocol.md`) defines behavioral rules for export authority, scope, and completeness (LEBOSS-DPP-1 through DPP-28).
+
+What the standard has not established is the **definition of a valid export** — the structural guarantees an export must satisfy to be considered portable. As a result:
+
+1. A system can produce an "export" that omits governance objects or audit history and technically satisfy the letter of the portability requirement.
+2. Nothing in the standard requires that exported data be sufficient to reconstruct the governed state — an export of raw data with no relationship information satisfies existing rules.
+3. Nothing in the standard prohibits proprietary export formats that require vendor tools to decode, making portability nominal rather than operational.
+4. GAP-3 in the normative rule register identifies the canonical encoding as partially unresolved. This proposal addresses the structural requirements; format encoding remains deferred.
+
+This proposal closes the gap on what makes an export valid without prescribing how export is implemented.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Expand §6.4 Data Portability
+
+Adds five numbered requirements defining what constitutes a valid export:
+
+1. **Completeness** — must include primary operational data, all governance objects, and all Audit Records within the retention window; no category omitted without governing entity authorization
+2. **Relationship preservation** — structural relationships between resources, governance objects, and Audit Records must be recoverable from the export alone
+3. **Reconstructability** — must be sufficient to rebuild the governed environment's operational state in an independent system
+4. **Format independence** — must use documented, non-proprietary formats with documentation sufficient for independent implementation
+5. **Manifest** — must include a manifest of categories, time range, and record counts for independent verification
+
+### 2. `standards/leboss-normative-rules.md` — Add PORT rule group
+
+Adds `PORT` (Data Portability Requirements) to the rule numbering registry with six rules:
+
+- **LEBOSS-PORT-1**: Completeness — complete export MUST include all primary operational data, governance objects, and Audit Records
+- **LEBOSS-PORT-2**: A conformant system MUST NOT produce an export omitting any governed resource category without authorization
+- **LEBOSS-PORT-3**: Relationship preservation — structural relationships MUST be recoverable from the export alone
+- **LEBOSS-PORT-4**: Reconstructability — export MUST be sufficient to rebuild operational state independently
+- **LEBOSS-PORT-5**: Format independence — exports MUST use documented, non-proprietary formats
+- **LEBOSS-PORT-6**: Manifest — exports MUST include a manifest for independent completeness verification
+
+Rule count: 52 → 58.
+
+Updates GAP-3 status to reflect resolution of structural requirements in 0.0.16.
+
+### 3. `standards/conformance.md` — Strengthen §3.5 and add conditions 10–11
+
+- §3.5 Data Portability: adds five specific portability conformance requirements referencing PORT rules
+- Non-conformance condition 10: **Non-reconstructable export** (LEBOSS-PORT-4)
+- Non-conformance condition 11: **Proprietary format dependency** (LEBOSS-PORT-5)
+
+### 4. `glossary/terms.md` — Add three new entries
+
+- **Complete Export** — the completeness requirement defined at standard level; normative rules PORT-1, PORT-2
+- **Export Manifest** — the structured verification artifact required with every export; normative rule PORT-6
+- **Reconstructable Export** — the reconstructability and format independence requirement; normative rules PORT-3, PORT-4, PORT-5
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Expand §6.4 with 5 portability requirements | Normative addition |
+| `standards/leboss-normative-rules.md` | Add PORT group (6 rules); rule count 52 → 58 | Normative addition |
+| `standards/conformance.md` | Strengthen §3.5; add conditions 10–11 | Normative addition |
+| `glossary/terms.md` | Add 3 new entries | Clarification — no new requirements |
+
+---
+
+## Backward Compatibility
+
+Existing systems that produce complete, non-proprietary, independently usable exports are unaffected. The new requirements formalize what a well-designed portability mechanism already guarantees.
+
+A system that previously satisfied portability requirements by producing partial exports, exports in proprietary formats, or exports without relationship information may now fail conformance under LEBOSS-PORT-2, LEBOSS-PORT-4, or LEBOSS-PORT-5. This is intentional — the proposal elevates the portability requirement from "exports exist" to "exports are usable."
+
+---
+
+## Sequence Context
+
+- 0.0.13 — defined the specification/implementation boundary
+- 0.0.14 — required that normative requirements be operationally enforced
+- 0.0.15 — established audit records as the authoritative system of record
+- 0.0.16 — defined what constitutes a valid, portable, and interoperable export
+
+---
+
+*Proposal 0.0.16 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.15
+**Updated Through:** proposal/0.0.16
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -124,6 +124,14 @@ A conformant system **MUST** support data portability, allowing the governing en
 
 The portability mechanism **MUST** be available at any time, not only upon termination of a service relationship.
 
+A conformant system **MUST** produce exports that are complete, relationship-preserving, reconstructable, and format-independent. Specifically:
+
+- Exports **MUST** include all governed resource categories — primary operational data, governance objects, and audit records — without omission (LEBOSS-PORT-1, LEBOSS-PORT-2).
+- Exports **MUST** preserve the structural relationships between resources, governance objects, and Audit Records so that those relationships are recoverable from the export alone (LEBOSS-PORT-3).
+- Exports **MUST** be sufficient to reconstruct the governed environment's operational state in an independent system without reliance on the exporting system or its service providers (LEBOSS-PORT-4).
+- Exports **MUST** use documented, non-proprietary formats with documentation sufficient for independent implementation (LEBOSS-PORT-5).
+- Exports **MUST** include a manifest identifying resource categories, time range, and record counts (LEBOSS-PORT-6).
+
 ### 3.6 Audit History Access
 
 A conformant system **MUST** maintain a verifiable audit history accessible to the governing entity.
@@ -163,6 +171,10 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 8. **Unenforced requirements** — normative requirements governing data access, grant validation, grant revocation, audit record creation, or data export are satisfied by documentation, policy declaration, or stated intent only, without operational enforcement (LEBOSS-ENF-1, LEBOSS-ENF-2).
 
 9. **Irreconcilable state** — the system represents the state of a governed resource in a manner that cannot be reconciled with the Audit Record history for that resource (LEBOSS-REC-2).
+
+10. **Non-reconstructable export** — the data portability mechanism produces exports that are insufficient to reconstruct the governed environment's operational state in an independent system without reliance on the exporting system or its service providers (LEBOSS-PORT-4).
+
+11. **Proprietary format dependency** — exports require proprietary tools, vendor-controlled systems, or undocumented formats to access, parse, or interpret, making them inaccessible to independent implementation (LEBOSS-PORT-5).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.15
+**Updated Through:** proposal/0.0.16
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -27,6 +27,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `SPEC` — Specification Boundary Rules
 - `ENF` — Enforcement Responsibility Rules
 - `REC` — Audit as System of Record Rules
+- `PORT` — Data Portability Requirements Rules
 
 ---
 
@@ -282,6 +283,34 @@ The LEBOSS standard MUST NOT prescribe how the system of record is stored or pro
 
 ---
 
+## Data Portability Requirements Rules
+
+**LEBOSS-PORT-1**
+A complete export MUST include all primary operational data, all governance objects (Access Grants, Integration Descriptors), and all Audit Records within the system's retention window.
+*Source: §6.4*
+
+**LEBOSS-PORT-2**
+A conformant system MUST NOT produce an export that omits any governed resource category without explicit governing entity authorization.
+*Source: §6.4*
+
+**LEBOSS-PORT-3**
+An export MUST preserve the structural relationships between resources, governance objects, and Audit Records such that those relationships are recoverable from the export alone.
+*Source: §6.4*
+
+**LEBOSS-PORT-4**
+An export MUST be sufficient to reconstruct the governed environment's operational state in an independent system without reliance on the exporting system or its service providers.
+*Source: §6.4*
+
+**LEBOSS-PORT-5**
+Exports MUST use documented, non-proprietary formats. The documentation for the export format MUST be sufficient for an independent party to implement a reader without access to proprietary tools or vendor assistance.
+*Source: §6.4*
+
+**LEBOSS-PORT-6**
+Exports MUST include a manifest identifying the resource categories included, the time range covered, and the record counts for each category, sufficient for the governing entity to verify completeness independently.
+*Source: §6.4*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -295,7 +324,8 @@ The LEBOSS standard MUST NOT prescribe how the system of record is stored or pro
 | Specification Boundary (SPEC)       | 4  | 2  | 2  | 1 | — |
 | Enforcement Responsibility (ENF)    | 4  | 2  | 3  | — | — |
 | Audit as System of Record (REC)     | 4  | 2  | 2  | — | — |
-| **Total**                           | **52** | **36** | **17** | **5** | **—** |
+| Data Portability Requirements (PORT) | 6 | 5  | 1  | — | — |
+| **Total**                           | **58** | **41** | **18** | **5** | **—** |
 
 ---
 
@@ -309,8 +339,8 @@ The standard requires that access grants specify scope, operations, duration, an
 **GAP-2: Audit Trail Format** — *Resolved in 0.0.3 and 0.0.6*
 The standard requires auditable records (LEBOSS-SEC-3, LEBOSS-SVC-3). The Audit Record object (`standards/objects/audit-record.md`) defines the required fields. The Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`) defines capture, correlation, retention, and integrity behavioral rules (LEBOSS-ACP-1 through ACP-24).
 
-**GAP-3: Portability Format** — *Partially resolved in 0.0.7*
-The standard requires machine-readable export (LEBOSS-OWN-3, LEBOSS-SVC-1). The Data Portability Protocol (`standards/leboss-data-portability-protocol.md`) defines export authority, scope, completeness, and neutrality behavioral rules (LEBOSS-DPP-1 through DPP-28). A specific LEBOSS Portability Format (canonical encoding) is deferred to a future proposal.
+**GAP-3: Portability Format** — *Partially resolved — export requirements defined; canonical encoding remains deferred*
+The standard requires machine-readable export (LEBOSS-OWN-3, LEBOSS-SVC-1). The Data Portability Protocol (`standards/leboss-data-portability-protocol.md`) defines export authority, scope, completeness, and neutrality behavioral rules (LEBOSS-DPP-1 through DPP-28). Proposal 0.0.16 added standard-level requirements for export completeness, relationship preservation, reconstructability, format independence, and manifests (LEBOSS-PORT-1 through PORT-6). A specific canonical encoding format remains deferred to a future proposal.
 
 **GAP-4: External Integration Authorization Protocol** — *Resolved in 0.0.3 and 0.0.5*
 LEBOSS-ACC-5 requires explicit authorization for external integrations. The Integration Descriptor object (`standards/objects/integration-descriptor.md`) defines what must be recorded. The Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`) defines the full integration lifecycle and behavioral rules (LEBOSS-IDP-1 through IDP-26).
@@ -320,4 +350,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.12. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.16. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.15
+**Updated Through:** proposal/0.0.16
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -405,6 +405,18 @@ A LEBOSS-compliant system **MUST** provide the governing entity with the ability
 
 Data portability is a requirement of ownership. A system that cannot return data to the owner is a system that has appropriated it.
 
+A valid export under this standard **MUST** satisfy the following requirements:
+
+1. **Completeness** — An export **MUST** include all primary operational data, all governance objects (including Access Grants and Integration Descriptors), and all Audit Records within the system's retention window. A conformant system **MUST NOT** produce an export that omits any governed resource category without explicit governing entity authorization.
+
+2. **Relationship preservation** — An export **MUST** preserve the structural relationships between resources, governance objects, and Audit Records such that those relationships are recoverable from the export alone.
+
+3. **Reconstructability** — An export **MUST** be sufficient to reconstruct the governed environment's operational state in an independent system without reliance on the exporting system, its service providers, or proprietary infrastructure.
+
+4. **Format independence** — Exports **MUST** use documented, non-proprietary formats. The documentation for the export format **MUST** be sufficient for an independent party to implement a reader without access to proprietary tools or vendor assistance.
+
+5. **Manifest** — Exports **MUST** include a manifest identifying the resource categories included, the time range covered, and the record counts for each category, sufficient for the governing entity to verify completeness independently.
+
 ### 6.5 Data Residency
 
 The governing entity **MUST** be informed of where primary operational data is stored and processed, including the jurisdiction of that infrastructure.
@@ -701,4 +713,4 @@ The full model, including 23 normative rules (LEBOSS-RM-1 through RM-23) and def
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.15 — Open for community review and pull request contribution.*
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.16 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Proposal 0.0.16 formalizes what constitutes a **valid, portable, and interoperable export** in a LEBOSS-compliant system. The standard previously required that exports exist and be machine-readable; this proposal defines what makes an export *sufficient* — complete, relationship-preserving, reconstructable, and format-independent.

Closes GAP-3 (partial) from the normative rule register.

## Changes

- **`standards/leboss-standard.md`** — Expands §6.4 with 5 numbered portability requirements (completeness, relationship preservation, reconstructability, format independence, manifest)
- **`standards/leboss-normative-rules.md`** — Adds PORT rule group (LEBOSS-PORT-1 through PORT-6); rule count 52 → 58
- **`standards/conformance.md`** — Strengthens §3.5; adds non-conformance conditions 10 (non-reconstructable export) and 11 (proprietary format dependency)
- **`glossary/terms.md`** — Adds Complete Export, Export Manifest, Reconstructable Export

## Sequence

- 0.0.13 — specification/implementation boundary
- 0.0.14 — operational enforcement required
- 0.0.15 — audit as system of record
- **0.0.16 — valid export definition**

## Constraints Satisfied

- No specific file formats defined (JSON, XML, etc.)
- No schemas or field-level structures
- No APIs, endpoints, or transport mechanisms
- No implementation details
- All requirements are normative (MUST / MUST NOT)