### PR TITLE
feat(standards): define cross-system resource identity and mapping (0.0.17)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.16
+**Updated Through:** proposal/0.0.17
 
 ---
 
@@ -553,6 +553,30 @@ Resource identifiers appear in Access Grant `scope` fields, Audit Record `resour
 See also: *Resource*, *Resource Namespace*
 
 Full model: [`standards/leboss-resource-model.md`](../standards/leboss-resource-model.md)
+
+---
+
+## Cross-System Resource Mapping
+
+The requirement that a receiving system be able to map each resource in a LEBOSS export to an internal equivalent, without access to the source system or its service providers. Cross-system mapping depends on each resource carrying sufficient identity information — including namespace context — within the export package.
+
+A system that imports a LEBOSS export MUST be able to establish the identity and relationships of every resource from the export alone. Mapping that requires querying the source system, accessing proprietary tooling, or relying on undocumented processes does not satisfy this requirement.
+
+Normative rules: LEBOSS-MAP-3, LEBOSS-MAP-4, LEBOSS-MAP-5, LEBOSS-MAP-6.
+
+See also: *Identity Portability*, *Resource Identifier*, *Resource Namespace*, *Reconstructable Export*
+
+---
+
+## Identity Portability
+
+The requirement that a governed resource's identity — the stable label by which it is referenced in governance objects — persists through export and import without alteration. A resource exported from one LEBOSS-compliant system and imported into another carries its original identity, keeping all Access Grants, Audit Records, and Integration Descriptors that reference that resource valid across environments.
+
+Identity portability requires that the export include namespace definitions sufficient for the receiving system to resolve every identifier independently, and that the identity used in the export match the identity used in governance objects within the source environment.
+
+Normative rules: LEBOSS-MAP-1, LEBOSS-MAP-2.
+
+See also: *Cross-System Resource Mapping*, *Resource Identifier*, *Resource Namespace*
 
 ---
 

--- a/proposals/0.0.17/proposal.md
+++ b/proposals/0.0.17/proposal.md
@@ -1,0 +1,102 @@
+# Proposal 0.0.17 — Cross-System Resource Identity and Mapping
+
+**Status:** Draft
+**Target Version:** 0.0.17
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `standards/leboss-resource-model.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal defines the requirements for **stable resource identity and cross-system mapping** in a LEBOSS-compliant system. The standard already requires that exports be complete, relationship-preserving, and reconstructable. What it has not specified is what must be true about resource identity to make that reconstruction operationally achievable — specifically, that identity must survive export and import unaltered, and that a receiving system must be able to map imported resources to internal equivalents without source system access.
+
+This proposal closes that gap at the standard level, without prescribing identifier formats, schemas, mapping algorithms, or implementation details.
+
+---
+
+## Motivation
+
+The LEBOSS standard establishes data portability as a normative requirement (§6.4, LEBOSS-OWN-3, LEBOSS-SVC-1). Proposal 0.0.16 defined what constitutes a valid export: complete, relationship-preserving, reconstructable, format-independent, and manifest-bearing.
+
+What remains undefined is the **identity layer** that makes cross-system reconstruction possible. As a result:
+
+1. A system can produce a complete, well-structured export whose resource identities are system-internal values — meaningful only within the source system's database — with no path to resolution in a receiving system.
+2. Nothing in the standard requires that a receiving system be able to map imported resources to internal equivalents; the import side of portability is unspecified.
+3. Nothing in the standard requires that structural relationships between resources remain resolvable after import.
+4. The Resource Model (`leboss-resource-model.md` §9) explicitly defers "cross-environment resource mapping" to a future proposal. This proposal closes that deferred item.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Add §17 Cross-System Resource Identity and Mapping
+
+Adds a new section after §16 (Resource Model) establishing six behavioral requirements:
+
+1. Every governed resource MUST have a stable identity within its environment
+2. Resource identity MUST persist through export and import without alteration
+3. Exports MUST include sufficient identity information for independent mapping
+4. A receiving system MUST be able to map imported resources without source system access
+5. Structural relationships MUST remain resolvable after import
+6. Identity and mapping MUST NOT depend on proprietary mechanisms
+
+### 2. `standards/leboss-normative-rules.md` — Add MAP rule group
+
+Adds `MAP` (Cross-System Resource Identity and Mapping Rules) to the rule numbering registry with six rules:
+
+- **LEBOSS-MAP-1**: Stable identity — governed resources MUST have stable identity within their environment
+- **LEBOSS-MAP-2**: Identity persistence — identity MUST persist through export and import without alteration
+- **LEBOSS-MAP-3**: Export sufficiency — exports MUST include sufficient identity information for independent mapping
+- **LEBOSS-MAP-4**: Receiving system mapping — receiving system MUST be able to map imported resources without source system access
+- **LEBOSS-MAP-5**: Relationship resolvability — structural relationships MUST remain resolvable after import
+- **LEBOSS-MAP-6**: No proprietary dependency — identity and mapping MUST NOT depend on proprietary mechanisms
+
+Rule count: 58 → 64.
+
+### 3. `standards/conformance.md` — Add §3.8 and conditions 12–13
+
+- §3.8 Cross-System Resource Identity and Mapping: six specific requirements referencing MAP rules
+- Non-conformance condition 12: **Identity-breaking import** (LEBOSS-MAP-4)
+- Non-conformance condition 13: **Proprietary identity dependency** (LEBOSS-MAP-6)
+
+### 4. `standards/leboss-resource-model.md` — Resolve §9 deferred item
+
+Removes the "Cross-environment resource mapping — deferred" item from §9 Model Boundaries and adds a reference to LEBOSS-MAP-1 through MAP-6.
+
+### 5. `glossary/terms.md` — Add two new entries
+
+- **Cross-System Resource Mapping** — the mapping requirement for receiving systems; normative rules MAP-3, MAP-4, MAP-5, MAP-6
+- **Identity Portability** — identity persistence through export and import; normative rules MAP-1, MAP-2
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §17 with 6 behavioral requirements | Normative addition |
+| `standards/leboss-normative-rules.md` | Add MAP group (6 rules); rule count 58 → 64 | Normative addition |
+| `standards/conformance.md` | Add §3.8; add conditions 12–13 | Normative addition |
+| `standards/leboss-resource-model.md` | Resolve §9 deferred item | Clarification — no new requirements |
+| `glossary/terms.md` | Add 2 new entries | Clarification — no new requirements |
+
+---
+
+## Backward Compatibility
+
+Existing systems that produce complete, format-independent exports with stable, namespace-qualified identifiers — as already required by LEBOSS-RM-4 and LEBOSS-RM-5 — are unaffected. The new requirements formalize what a well-designed portability mechanism already guarantees on the identity layer.
+
+A system whose resource identifiers are system-internal values with no external resolution path, or whose export omits identity context sufficient for a receiving system to perform mapping, may now fail conformance under LEBOSS-MAP-3 or LEBOSS-MAP-4. This is intentional — the proposal elevates identity portability from implied to normative.
+
+---
+
+## Sequence Context
+
+- 0.0.14 — required that normative requirements be operationally enforced
+- 0.0.15 — established audit records as the authoritative system of record
+- 0.0.16 — defined what constitutes a valid, portable, and interoperable export
+- 0.0.17 — defined what must be true about resource identity for cross-system migration to be achievable
+
+---
+
+*Proposal 0.0.17 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.16
+**Updated Through:** proposal/0.0.17
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -148,6 +148,17 @@ Documentation of compliance, policy declarations, and stated intent do not const
 
 Operational enforcement is required across all governed action categories: data access, grant validation, grant revocation, audit record creation, and data export.
 
+### 3.8 Cross-System Resource Identity and Mapping
+
+A conformant system **MUST** ensure that governed resources carry stable, portable identity sufficient to support cross-system migration. Specifically:
+
+- Every governed resource **MUST** have a stable identity within its environment that does not depend on system-internal state absent from an export (LEBOSS-MAP-1).
+- Resource identity **MUST** persist through export and import without alteration — the identity used in governance objects **MUST** match the identity carried in the export (LEBOSS-MAP-2).
+- Exports **MUST** include sufficient identity information for each resource to enable a receiving system to uniquely identify and map that resource independently (LEBOSS-MAP-3).
+- A receiving system importing a LEBOSS export **MUST** be able to map each imported resource to an internal equivalent without requiring access to the source system (LEBOSS-MAP-4).
+- Structural relationships between resources **MUST** remain resolvable after import (LEBOSS-MAP-5).
+- Resource identity and mapping **MUST NOT** depend on proprietary mechanisms, vendor-controlled systems, or undocumented processes (LEBOSS-MAP-6).
+
 ---
 
 ## 4. Non-Conformance Conditions
@@ -175,6 +186,10 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 10. **Non-reconstructable export** — the data portability mechanism produces exports that are insufficient to reconstruct the governed environment's operational state in an independent system without reliance on the exporting system or its service providers (LEBOSS-PORT-4).
 
 11. **Proprietary format dependency** — exports require proprietary tools, vendor-controlled systems, or undocumented formats to access, parse, or interpret, making them inaccessible to independent implementation (LEBOSS-PORT-5).
+
+12. **Identity-breaking import** — the system fails to map imported resources to internal equivalents, or the import process alters resource identities such that governance objects referencing those resources become unresolvable (LEBOSS-MAP-4).
+
+13. **Proprietary identity dependency** — resource identity or cross-system mapping depends on proprietary mechanisms, vendor-controlled systems, or undocumented processes, preventing independent migration without source system access (LEBOSS-MAP-6).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.16
+**Updated Through:** proposal/0.0.17
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -28,6 +28,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `ENF` — Enforcement Responsibility Rules
 - `REC` — Audit as System of Record Rules
 - `PORT` — Data Portability Requirements Rules
+- `MAP` — Cross-System Resource Identity and Mapping Rules
 
 ---
 
@@ -311,6 +312,34 @@ Exports MUST include a manifest identifying the resource categories included, th
 
 ---
 
+## Cross-System Resource Identity and Mapping Rules
+
+**LEBOSS-MAP-1**
+Every governed resource MUST have a stable identity within its environment. An identity that changes over time, or that depends on system-internal state not present in an export, cannot serve as a basis for governance continuity across systems.
+*Source: §17*
+
+**LEBOSS-MAP-2**
+Resource identity MUST persist through export and import without alteration. The identity a resource carries in an export package MUST be the same identity used to reference it in governance objects — Access Grants, Audit Records, and Integration Descriptors — within that environment.
+*Source: §17*
+
+**LEBOSS-MAP-3**
+An export MUST include sufficient identity information for each resource to enable a receiving system to uniquely identify and map that resource independently, without access to the source system or its service providers.
+*Source: §17*
+
+**LEBOSS-MAP-4**
+A receiving system importing a LEBOSS export MUST be able to map each imported resource to an internal equivalent without requiring access to the source system or its service providers.
+*Source: §17*
+
+**LEBOSS-MAP-5**
+Structural relationships between resources MUST remain resolvable in the receiving system after import. An import that renders previously resolvable relationships between resources unresolvable does not satisfy this standard.
+*Source: §17*
+
+**LEBOSS-MAP-6**
+Resource identity and mapping MUST NOT depend on proprietary mechanisms, vendor-controlled systems, or undocumented processes.
+*Source: §17*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -325,7 +354,8 @@ Exports MUST include a manifest identifying the resource categories included, th
 | Enforcement Responsibility (ENF)    | 4  | 2  | 3  | — | — |
 | Audit as System of Record (REC)     | 4  | 2  | 2  | — | — |
 | Data Portability Requirements (PORT) | 6 | 5  | 1  | — | — |
-| **Total**                           | **58** | **41** | **18** | **5** | **—** |
+| Cross-System Identity and Mapping (MAP) | 6 | 5  | 1  | — | — |
+| **Total**                           | **64** | **46** | **19** | **5** | **—** |
 
 ---
 
@@ -350,4 +380,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.16. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.17. The standard governs in all cases of conflict.*

--- a/standards/leboss-resource-model.md
+++ b/standards/leboss-resource-model.md
@@ -185,9 +185,9 @@ This model does not define:
 - **Resource lifecycle management** — how resources are created, versioned, archived, or deleted is outside this specification; a Resource Lifecycle Protocol is deferred to a future proposal
 - **Resource discovery** — how parties enumerate available resources within a governed environment is outside this specification
 - **Type taxonomy enforcement** — while required type categories are defined, mandatory sub-classifications within categories are outside this specification
-- **Cross-environment resource mapping** — how resources are matched between source and destination environments during migration is outside this specification
-
 These concerns will be addressed in future proposals.
+
+Cross-environment resource mapping requirements — what must be true about resource identity and mapping to enable migration between systems — are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md) (LEBOSS-MAP-1 through MAP-6), added in proposal 0.0.17.
 
 ---
 

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.16
+**Updated Through:** proposal/0.0.17
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -713,4 +713,23 @@ The full model, including 23 normative rules (LEBOSS-RM-1 through RM-23) and def
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.16 — Open for community review and pull request contribution.*
+## 17. Cross-System Resource Identity and Mapping
+
+The LEBOSS portability doctrine holds that a governing entity must be able to move their operational environment to another system without loss of governance continuity. The Data Portability Protocol (§15) defines what must be exported. Proposal 0.0.16 established the structural requirements for a valid export. This section defines what must be true about resource identity and cross-system mapping to make portability operationally achievable.
+
+A complete, format-independent export is necessary but not sufficient for portability. For a governing entity to reconstruct their governed environment in a receiving system, each exported resource must carry identity information sufficient to be uniquely identified, mapped to a corresponding resource in the destination, and reconnected to its relationships — without reference to the source system or its infrastructure.
+
+**Key behavioral requirements:**
+
+- Every governed resource MUST have a stable identity within its environment. An identity that changes over time, or that depends on system-internal state not present in the export, cannot serve as a basis for governance continuity across systems.
+- Resource identity MUST persist through export and import without alteration. The identity a resource carries in the export package MUST be the same identity used to reference it in governance objects — Access Grants, Audit Records, and Integration Descriptors.
+- An export MUST include sufficient identity information for each resource to enable a receiving system to uniquely identify and map that resource independently, without access to the source system.
+- A receiving system importing a LEBOSS export MUST be able to map each imported resource to an internal equivalent without requiring access to the source system or its service providers.
+- Structural relationships between resources MUST remain resolvable in the receiving system after import. An import that renders previously resolvable relationships unresolvable does not satisfy this standard.
+- Resource identity and mapping MUST NOT depend on proprietary mechanisms, vendor-controlled systems, or undocumented processes.
+
+The normative rules for cross-system resource identity and mapping (LEBOSS-MAP-1 through MAP-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.17 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Proposal 0.0.17 defines the requirements for stable resource identity and cross-system mapping in a LEBOSS-compliant system.

- Adds §17 to `leboss-standard.md` establishing six behavioral requirements for identity portability and cross-system mapping
- Adds `MAP` rule group (LEBOSS-MAP-1 through MAP-6) to `leboss-normative-rules.md`; rule count 58 → 64
- Adds §3.8 and non-conformance conditions 12–13 to `conformance.md`
- Resolves the deferred "cross-environment resource mapping" item in `leboss-resource-model.md` §9
- Adds two glossary entries: *Cross-System Resource Mapping* and *Identity Portability*

## Motivation

Proposal 0.0.16 established what constitutes a valid export. What remained undefined was the identity layer that makes cross-system reconstruction operationally achievable. The Resource Model §9 explicitly deferred this; 0.0.17 closes that deferred item.

## Sequence

- 0.0.15 — audit records as authoritative system of record
- 0.0.16 — valid, portable, interoperable export requirements
- 0.0.17 — resource identity and mapping requirements for cross-system migration