### PR TITLE
feat(standards): define delegation and authority chain constraints (0.0.18)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.17
+**Updated Through:** proposal/0.0.18
 
 ---
 
@@ -160,6 +160,28 @@ Contributors do not hold voting authority on the committee but their participati
 ## LEBOSS Elements
 
 The six hierarchical architectural elements defined by the LEBOSS standard: Universe (0), Galaxy (1), Star (2), Planet (3), Moon (4), and Satellite (5). Together, the LEBOSS Elements form a complete vocabulary for describing the structure of a local business's digital ecosystem.
+
+---
+
+## Authority Chain
+
+The traceable sequence of grants from a delegated action back to the root governing entity grant. Every access action authorized through a delegated grant must be resolvable to an authority chain that terminates at a valid grant issued by the governing entity. An authority chain that cannot be fully traced, that contains a revoked link, or that terminates at an unknown or invalid authority does not satisfy LEBOSS delegation requirements.
+
+Normative rules: LEBOSS-DEL-2, LEBOSS-DEL-3, LEBOSS-DEL-4.
+
+See also: *Delegated Grant*, *Access Grant*, *Governing Entity*
+
+---
+
+## Delegated Grant
+
+An Access Grant issued by a delegate acting on behalf of the governing entity, rather than directly by the governing entity. A delegated grant must reference the originating grant that authorized the delegation, must not exceed the scope, operations, or duration of the delegating grant, and must be invalidated when the originating grant is revoked.
+
+Delegation authority must be explicitly included in the delegate's own Access Grant. Delegation does not create implicit or inherited access — every step in a delegation chain is bounded by explicit grant scope.
+
+Normative rules: LEBOSS-DEL-1, LEBOSS-DEL-2, LEBOSS-DEL-5, LEBOSS-DEL-6.
+
+See also: *Authority Chain*, *Access Grant*, *Governing Entity*
 
 ---
 

--- a/proposals/0.0.18/proposal.md
+++ b/proposals/0.0.18/proposal.md
@@ -1,0 +1,104 @@
+# Proposal 0.0.18 — Delegation and Authority Chain Constraints
+
+**Status:** Draft
+**Target Version:** 0.0.18
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `standards/objects/access-grant.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal formalizes the structural constraints that make **delegated access authority safe** in a LEBOSS-compliant system. The standard already permits delegation — a governing entity may designate a delegate to issue Access Grants on their behalf. What it has not established is the constraints that delegation must satisfy: scope bounding, traceability from any delegated action to its root authority, revocation cascade, and prohibition of implicit or inherited access.
+
+This proposal closes that gap at the standard level, without prescribing delegation architectures, role systems, or implementation mechanisms.
+
+---
+
+## Motivation
+
+The LEBOSS access control doctrine requires explicit, scoped Access Grants (§6.3, LEBOSS-ACC-1). The Access Grant Protocol (§12) operationalizes grants at the behavioral level. The Access Grant object (`objects/access-grant.md`) defines the `delegated_from` field and notes that "a delegate MUST NOT issue grants with broader scope or permissions than their own delegated authority."
+
+What the standard has not established is the **structural constraints on delegation chains**:
+
+1. The scope-bounding requirement exists only at the protocol level (AGP §4.3), not at the standard level. A conformance claim cannot be made against a protocol rule alone.
+2. Nothing in the standard requires that a delegation chain be fully traceable to a root governing entity grant — only that individual delegated grants reference their immediate originator.
+3. Nothing in the standard requires revocation cascade — that revoking a parent grant automatically invalidates all dependent delegated grants.
+4. `objects/access-grant.md` §5 explicitly states: "The delegation model itself is not fully specified in this version and will be addressed in a future proposal."
+
+This proposal closes that deferred item.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Add §18 Delegation and Authority Chains
+
+Adds a new section establishing six behavioral requirements for delegation:
+
+1. Delegated authority MUST NOT exceed the scope of the delegating grant
+2. A delegated grant MUST reference its originating grant
+3. Delegation chains MUST be fully traceable to the root governing entity grant
+4. Revocation MUST propagate to all dependent delegated grants
+5. A conformant system MUST NOT permit chains that create untraceable or ambiguous authority
+6. Delegation MUST NOT create implicit or inherited access
+
+### 2. `standards/leboss-normative-rules.md` — Add DEL rule group
+
+Adds `DEL` (Delegation and Authority Chain Rules) to the rule numbering registry with six rules:
+
+- **LEBOSS-DEL-1**: Scope bounding — delegated authority MUST NOT exceed the delegator's grant
+- **LEBOSS-DEL-2**: Originating reference — a delegated grant MUST reference its originating grant
+- **LEBOSS-DEL-3**: Full traceability — delegation chains MUST trace to the root governing entity grant
+- **LEBOSS-DEL-4**: Revocation cascade — revocation MUST propagate to all dependent grants
+- **LEBOSS-DEL-5**: No untraceable chains — system MUST NOT permit ambiguous or unauditable chains
+- **LEBOSS-DEL-6**: No implicit access — delegation MUST NOT create implicit or inherited access
+
+Rule count: 64 → 70.
+
+### 3. `standards/conformance.md` — Add §3.9 and conditions 14–15
+
+- §3.9 Delegation and Authority Chains: six specific requirements referencing DEL rules
+- Non-conformance condition 14: **Unbounded delegation** (LEBOSS-DEL-1)
+- Non-conformance condition 15: **Untraceable authority chain** (LEBOSS-DEL-3, DEL-4, DEL-5)
+
+### 4. `standards/objects/access-grant.md` — Resolve §5 deferred item
+
+Replaces the "delegation model not fully specified" note in §5 with a reference to LEBOSS-DEL-1 through DEL-6 (proposal 0.0.18).
+
+### 5. `glossary/terms.md` — Add two new entries
+
+- **Authority Chain** — the traceable sequence of grants from a delegated action to the root governing entity grant; normative rules DEL-2, DEL-3, DEL-4
+- **Delegated Grant** — an Access Grant issued by a delegate; normative rules DEL-1, DEL-2, DEL-5, DEL-6
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §18 with 6 behavioral requirements | Normative addition |
+| `standards/leboss-normative-rules.md` | Add DEL group (6 rules); rule count 64 → 70 | Normative addition |
+| `standards/conformance.md` | Add §3.9; add conditions 14–15 | Normative addition |
+| `standards/objects/access-grant.md` | Resolve §5 deferred delegation model note | Clarification |
+| `glossary/terms.md` | Add 2 new entries | Clarification — no new requirements |
+
+---
+
+## Backward Compatibility
+
+Systems that already enforce delegation scope bounding and audit delegation chains are unaffected. The new rules formalize what a well-designed access control mechanism already guarantees.
+
+A system that permits delegates to issue grants beyond their own scope, does not propagate revocations through delegation chains, or permits opaque delegation structures may now fail conformance under LEBOSS-DEL-1, LEBOSS-DEL-4, or LEBOSS-DEL-5. This is intentional — the proposal elevates delegation constraints from implied to normative.
+
+---
+
+## Sequence Context
+
+- 0.0.15 — established audit records as the authoritative system of record
+- 0.0.16 — defined what constitutes a valid, portable, and interoperable export
+- 0.0.17 — defined resource identity and cross-system mapping requirements
+- 0.0.18 — defined delegation scope, traceability, and revocation cascade constraints
+
+---
+
+*Proposal 0.0.18 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.17
+**Updated Through:** proposal/0.0.18
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -159,6 +159,17 @@ A conformant system **MUST** ensure that governed resources carry stable, portab
 - Structural relationships between resources **MUST** remain resolvable after import (LEBOSS-MAP-5).
 - Resource identity and mapping **MUST NOT** depend on proprietary mechanisms, vendor-controlled systems, or undocumented processes (LEBOSS-MAP-6).
 
+### 3.9 Delegation and Authority Chains
+
+A conformant system **MUST** enforce structural constraints on delegated access authority. Specifically:
+
+- Delegated authority **MUST NOT** exceed the scope, operations, or duration of the grant from which it was delegated (LEBOSS-DEL-1).
+- Every delegated grant **MUST** reference the originating grant that authorized the delegation (LEBOSS-DEL-2).
+- Delegation chains **MUST** be fully traceable from any point to the root governing entity grant (LEBOSS-DEL-3).
+- Revocation of a grant **MUST** propagate to all dependent delegated grants (LEBOSS-DEL-4).
+- A conformant system **MUST NOT** permit delegation chains that introduce ambiguity in access authority or that cannot be fully audited (LEBOSS-DEL-5).
+- Delegation **MUST NOT** create implicit or inherited access outside explicit grant scope (LEBOSS-DEL-6).
+
 ---
 
 ## 4. Non-Conformance Conditions
@@ -190,6 +201,10 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 12. **Identity-breaking import** — the system fails to map imported resources to internal equivalents, or the import process alters resource identities such that governance objects referencing those resources become unresolvable (LEBOSS-MAP-4).
 
 13. **Proprietary identity dependency** — resource identity or cross-system mapping depends on proprietary mechanisms, vendor-controlled systems, or undocumented processes, preventing independent migration without source system access (LEBOSS-MAP-6).
+
+14. **Unbounded delegation** — the system permits a delegated grant to be issued with scope, operations, or duration exceeding those of the delegating grant, or permits delegation chains to extend beyond the bounds of the root governing entity grant (LEBOSS-DEL-1).
+
+15. **Untraceable authority chain** — the system permits delegation chains that cannot be traced to a valid root governing entity grant, or that introduce ambiguity in access authority, or that do not propagate revocation to all dependent grants (LEBOSS-DEL-3, LEBOSS-DEL-4, LEBOSS-DEL-5).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.17
+**Updated Through:** proposal/0.0.18
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -29,6 +29,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `REC` — Audit as System of Record Rules
 - `PORT` — Data Portability Requirements Rules
 - `MAP` — Cross-System Resource Identity and Mapping Rules
+- `DEL` — Delegation and Authority Chain Rules
 
 ---
 
@@ -340,6 +341,34 @@ Resource identity and mapping MUST NOT depend on proprietary mechanisms, vendor-
 
 ---
 
+## Delegation and Authority Chain Rules
+
+**LEBOSS-DEL-1**
+Delegated authority MUST NOT exceed the scope, operations, or duration of the grant from which it was delegated. A delegate cannot authorize more than they were themselves authorized to authorize.
+*Source: §18*
+
+**LEBOSS-DEL-2**
+A delegated grant MUST reference the originating grant that authorized the delegation. A grant with no traceable originating authority is invalid and MUST NOT be treated as a basis for access.
+*Source: §18*
+
+**LEBOSS-DEL-3**
+A delegation chain MUST be fully traceable from any point in the chain to the root governing entity grant. A chain that cannot be resolved to a valid root governing entity grant does not satisfy this standard.
+*Source: §18*
+
+**LEBOSS-DEL-4**
+Revocation of a grant MUST propagate to all grants in the delegation chain that depend on it. A delegated grant that continues to authorize access after its originating grant has been revoked constitutes a conformance failure.
+*Source: §18*
+
+**LEBOSS-DEL-5**
+A conformant system MUST NOT permit delegation chains that introduce ambiguity in access authority or that cannot be fully audited.
+*Source: §18*
+
+**LEBOSS-DEL-6**
+Delegation MUST NOT create implicit or inherited access. Access authorized through delegation is bounded by explicit grant scope at every step in the chain.
+*Source: §18*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -355,7 +384,8 @@ Resource identity and mapping MUST NOT depend on proprietary mechanisms, vendor-
 | Audit as System of Record (REC)     | 4  | 2  | 2  | — | — |
 | Data Portability Requirements (PORT) | 6 | 5  | 1  | — | — |
 | Cross-System Identity and Mapping (MAP) | 6 | 5  | 1  | — | — |
-| **Total**                           | **64** | **46** | **19** | **5** | **—** |
+| Delegation and Authority Chains (DEL)   | 6 | 3  | 3  | — | — |
+| **Total**                           | **70** | **49** | **22** | **5** | **—** |
 
 ---
 
@@ -380,4 +410,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.17. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.18. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.17
+**Updated Through:** proposal/0.0.18
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -732,4 +732,23 @@ The normative rules for cross-system resource identity and mapping (LEBOSS-MAP-1
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.17 — Open for community review and pull request contribution.*
+## 18. Delegation and Authority Chains
+
+The LEBOSS access control doctrine requires that every access to primary operational data be authorized by an explicit, scoped Access Grant issued by the governing entity or their designated delegate. The Access Grant Protocol operationalizes this requirement at the behavioral level. What the standard has not established is the structural constraints that make delegation safe — the guarantees that must hold across any chain of delegated authority to prevent scope expansion, audit gaps, and orphaned access.
+
+Delegation occurs when a party holding a valid Access Grant is authorized to issue grants to other parties within their own grant's scope. This is a legitimate governance pattern. It is unsafe when: a delegated grant expands beyond the delegator's authority; when the chain from a delegated action to its root authority cannot be established; or when revocation of a parent grant does not propagate to the grants that depend on it.
+
+**Key behavioral requirements:**
+
+- Delegated authority **MUST NOT** exceed the scope of the grant from which it was delegated. A delegate cannot authorize more than they were authorized to authorize.
+- A delegated grant **MUST** reference the originating grant that authorized the delegation. A grant with no traceable originating authority is invalid.
+- A delegation chain **MUST** be fully traceable from any point in the chain to the root governing entity grant. A chain that cannot be resolved to a valid root governing entity grant does not satisfy this standard.
+- Revocation of a grant **MUST** propagate to all grants in the delegation chain that depend on it. A delegated grant that continues to authorize access after its parent grant has been revoked constitutes a conformance failure.
+- A conformant system **MUST NOT** permit delegation chains that introduce ambiguity in access authority or that cannot be fully audited.
+- Delegation **MUST NOT** create implicit or inherited access. Access authorized through delegation is bounded by explicit grant scope at every step in the chain.
+
+The normative rules for delegation and authority chains (LEBOSS-DEL-1 through DEL-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.18 — Open for community review and pull request contribution.*

--- a/standards/objects/access-grant.md
+++ b/standards/objects/access-grant.md
@@ -96,7 +96,7 @@ Implementations MAY define additional operation types but MUST NOT grant access 
 
 A governing entity MAY designate a delegate to issue Access Grants on their behalf. Delegated grants MUST reference the `delegated_from` field to establish the chain of authority. A delegate MUST NOT issue grants with broader scope or permissions than their own delegated authority.
 
-The delegation model itself is not fully specified in this version and will be addressed in a future proposal.
+The standard-level constraints governing delegation — scope bounding, traceability, revocation cascade, and prohibition of implicit access — are defined in [`standards/leboss-normative-rules.md`](../leboss-normative-rules.md) (LEBOSS-DEL-1 through DEL-6), added in proposal 0.0.18.
 
 ---
 


### PR DESCRIPTION
## Summary

Proposal 0.0.18 formalizes the structural constraints on delegated access authority in a LEBOSS-compliant system.

- Adds §18 to `leboss-standard.md` establishing 6 behavioral requirements for delegation
- Adds `DEL` rule group (LEBOSS-DEL-1 through DEL-6) to `leboss-normative-rules.md`; rule count 64 → 70
- Adds §3.9 and non-conformance conditions 14–15 to `conformance.md`
- Resolves the deferred delegation model note in `standards/objects/access-grant.md` §5
- Adds two glossary entries: *Authority Chain* and *Delegated Grant*

## Motivation

The standard permitted delegation but had not established the structural constraints that make it safe. `objects/access-grant.md` §5 explicitly deferred the delegation model to a future proposal. This proposal closes that deferred item by formalizing scope bounding, traceability, revocation cascade, and prohibition of implicit access — at the standard level, without prescribing implementation.

## Sequence

- 0.0.16 — valid, portable, interoperable export requirements
- 0.0.17 — resource identity and cross-system mapping requirements
- 0.0.18 — delegation scope, traceability, and revocation cascade constraints