### PR TITLE
feat(standards): define conformance verification and certification requirements (0.0.19)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.18
+**Updated Through:** proposal/0.0.19
 
 ---
 
@@ -130,6 +130,26 @@ LEBOSS defines two conformance tiers:
 The term "LEBOSS-conformant" is not a defined LEBOSS conformance term.
 
 See also: *Reference Model*
+
+---
+
+## Conformance Claim
+
+A declaration that a system satisfies the requirements of a LEBOSS conformance tier (LEBOSS-aligned or LEBOSS-compliant). A conformance claim is valid only when it is supportable through observable system behavior and audit records. A conformance claim made in the presence of any non-conformance condition defined in [`standards/conformance.md`](../standards/conformance.md) §4 is invalid.
+
+Normative rules: LEBOSS-VER-1, LEBOSS-VER-2, LEBOSS-VER-3.
+
+See also: *Compliance*, *Conformance Evidence*, *Governing Entity*
+
+---
+
+## Conformance Evidence
+
+The observable artifacts — audit records, access grant records, and behavioral demonstrations of enforcement — that support a conformance claim. Conformance evidence must be independently examinable; documentation, policy declarations, and stated intent do not constitute conformance evidence.
+
+Normative rules: LEBOSS-VER-2, LEBOSS-VER-4, LEBOSS-VER-6.
+
+See also: *Conformance Claim*, *Audit Record*, *Compliance*
 
 ---
 

--- a/proposals/0.0.19/proposal.md
+++ b/proposals/0.0.19/proposal.md
@@ -1,0 +1,100 @@
+# Proposal 0.0.19 — Conformance Verification
+
+**Status:** Draft
+**Target Version:** 0.0.19
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal defines what it means for a LEBOSS conformance claim to be valid and verifiable. The standard has accumulated a complete set of normative rules across fourteen groups. What it has not established is the structural requirements governing how those rules are evaluated and how compliance is asserted.
+
+A system that satisfies all normative rules but makes no verifiable demonstration of that satisfaction provides no governance guarantee. This proposal closes that gap by formalizing that conformance must be demonstrable through observable system behavior, that partial compliance cannot be represented as full compliance, and that independent verification must be possible without relying on system-reported assertions alone.
+
+---
+
+## Motivation
+
+The LEBOSS standard defines conformance requirements in `standards/conformance.md` and normative rules across fourteen rule groups. What neither document establishes is:
+
+1. That compliance claims must be supportable through evidence — not assertion
+2. That partial satisfaction of normative rules may not be represented as full compliance
+3. That a system bearing any non-conformance condition cannot validly claim compliance
+4. That a system must provide sufficient visibility for independent verification
+5. That conformance levels (if any) must be clearly bounded and non-ambiguous
+6. That documentation and stated intent are categorically insufficient as compliance evidence
+
+These gaps make LEBOSS conformance claims difficult to evaluate. A system could declare compliance without exposing any means of independent verification. This proposal closes that by elevating verification from an implied expectation to a normative requirement.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Add §19 Conformance Verification
+
+Adds a new section establishing six behavioral requirements for conformance verification:
+
+1. A LEBOSS-compliant system MUST satisfy all applicable normative rules; partial satisfaction MUST NOT be represented as full compliance
+2. Compliance claims MUST be supportable through observable behavior and audit records
+3. A system MUST NOT claim compliance if any non-conformance condition is present
+4. A system MUST provide sufficient visibility for independent verification
+5. Where conformance levels are defined, they MUST be clearly bounded; partial satisfaction MUST NOT be represented as meeting a level
+6. Verification MUST NOT be satisfied by documentation or stated intent alone
+
+### 2. `standards/leboss-normative-rules.md` — Add VER rule group
+
+Adds `VER` (Conformance Verification Rules) to the rule numbering registry with six rules:
+
+- **LEBOSS-VER-1**: All normative rules MUST be satisfied; partial satisfaction MUST NOT be represented as full compliance
+- **LEBOSS-VER-2**: Compliance claims MUST be supportable through observable behavior and audit records; self-declaration MUST NOT constitute a valid claim
+- **LEBOSS-VER-3**: A system MUST NOT claim compliance if any non-conformance condition is present
+- **LEBOSS-VER-4**: A system MUST provide sufficient visibility for independent verification
+- **LEBOSS-VER-5**: Conformance levels MUST be clearly bounded; partial satisfaction MUST NOT be misrepresented
+- **LEBOSS-VER-6**: Verification MUST NOT be satisfied by documentation or stated intent alone
+
+Rule count: 70 → 76.
+
+### 3. `standards/conformance.md` — Add §3.10 and conditions 16–17
+
+- §3.10 Conformance Verification: six specific requirements referencing VER rules
+- Non-conformance condition 16: **False compliance claim** (LEBOSS-VER-1, VER-3)
+- Non-conformance condition 17: **Unverifiable conformance** (LEBOSS-VER-2, VER-4, VER-5, VER-6)
+
+### 4. `glossary/terms.md` — Add two new entries
+
+- **Conformance Claim** — a declaration that a system satisfies a LEBOSS conformance tier; valid only when supportable through observable evidence; normative rules VER-1, VER-2, VER-3
+- **Conformance Evidence** — observable artifacts that support a conformance claim; normative rules VER-2, VER-4, VER-6
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §19 with 6 behavioral requirements | Normative addition |
+| `standards/leboss-normative-rules.md` | Add VER group (6 rules); rule count 70 → 76 | Normative addition |
+| `standards/conformance.md` | Add §3.10; add conditions 16–17 | Normative addition |
+| `glossary/terms.md` | Add 2 new entries | Clarification — no new requirements |
+
+---
+
+## Backward Compatibility
+
+Systems that already enforce normative rules operationally and maintain audit records providing observable evidence of conformance are unaffected. These systems can already support independent verification.
+
+A system that claims compliance based solely on documentation, policy declarations, or stated intent — without operational enforcement or observable evidence — may now fail conformance under LEBOSS-VER-2 and LEBOSS-VER-6. This is intentional: the proposal elevates verifiability from an implied expectation to an explicit normative requirement.
+
+---
+
+## Sequence Context
+
+- 0.0.15 — established audit records as the authoritative system of record
+- 0.0.16 — defined what constitutes a valid, portable, and interoperable export
+- 0.0.17 — defined resource identity and cross-system mapping requirements
+- 0.0.18 — defined delegation scope, traceability, and revocation cascade constraints
+- 0.0.19 — defined conformance verification: verifiability, evidence requirements, and claim validity
+
+---
+
+*Proposal 0.0.19 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.18
+**Updated Through:** proposal/0.0.19
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -170,6 +170,17 @@ A conformant system **MUST** enforce structural constraints on delegated access 
 - A conformant system **MUST NOT** permit delegation chains that introduce ambiguity in access authority or that cannot be fully audited (LEBOSS-DEL-5).
 - Delegation **MUST NOT** create implicit or inherited access outside explicit grant scope (LEBOSS-DEL-6).
 
+### 3.10 Conformance Verification
+
+A conformant system **MUST** satisfy the conditions under which its compliance claim can be independently verified. Specifically:
+
+- A conformant system **MUST** satisfy all applicable normative rules. Partial satisfaction of normative rules **MUST NOT** be represented as full compliance (LEBOSS-VER-1).
+- Compliance claims **MUST** be supportable through observable system behavior and audit records. Self-declaration without supporting evidence **MUST NOT** constitute a valid compliance claim (LEBOSS-VER-2).
+- A system **MUST NOT** claim LEBOSS compliance if any non-conformance condition in §4 of this document is present (LEBOSS-VER-3).
+- A system **MUST** provide sufficient visibility into its governed operations to allow an independent party to verify conformance without relying solely on system-reported assertions (LEBOSS-VER-4).
+- Where conformance levels are defined, those levels **MUST** be clearly bounded and non-ambiguous. A system **MUST NOT** represent partial satisfaction of a conformance level as meeting that level (LEBOSS-VER-5).
+- Verification **MUST NOT** be satisfied by documentation, policy declaration, or stated intent alone. Conformance requires observable evidence of enforcement in governed operations (LEBOSS-VER-6).
+
 ---
 
 ## 4. Non-Conformance Conditions
@@ -205,6 +216,10 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 14. **Unbounded delegation** — the system permits a delegated grant to be issued with scope, operations, or duration exceeding those of the delegating grant, or permits delegation chains to extend beyond the bounds of the root governing entity grant (LEBOSS-DEL-1).
 
 15. **Untraceable authority chain** — the system permits delegation chains that cannot be traced to a valid root governing entity grant, or that introduce ambiguity in access authority, or that do not propagate revocation to all dependent grants (LEBOSS-DEL-3, LEBOSS-DEL-4, LEBOSS-DEL-5).
+
+16. **False compliance claim** — the system claims LEBOSS compliance while any non-conformance condition in this section is present, or while any applicable normative rule is unsatisfied (LEBOSS-VER-1, LEBOSS-VER-3).
+
+17. **Unverifiable conformance** — the system does not provide sufficient visibility into its governed operations to allow an independent party to verify conformance, or represents partial satisfaction of normative rules as full compliance (LEBOSS-VER-2, LEBOSS-VER-4, LEBOSS-VER-5, LEBOSS-VER-6).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.18
+**Updated Through:** proposal/0.0.19
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -30,6 +30,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `PORT` — Data Portability Requirements Rules
 - `MAP` — Cross-System Resource Identity and Mapping Rules
 - `DEL` — Delegation and Authority Chain Rules
+- `VER` — Conformance Verification Rules
 
 ---
 
@@ -369,6 +370,34 @@ Delegation MUST NOT create implicit or inherited access. Access authorized throu
 
 ---
 
+## Conformance Verification Rules
+
+**LEBOSS-VER-1**
+A LEBOSS-compliant system MUST satisfy all applicable normative rules. Partial satisfaction of normative rules MUST NOT be represented as full compliance.
+*Source: §19*
+
+**LEBOSS-VER-2**
+Compliance claims MUST be supportable through observable system behavior and audit records. Self-declaration without supporting evidence MUST NOT constitute a valid compliance claim.
+*Source: §19*
+
+**LEBOSS-VER-3**
+A system MUST NOT claim LEBOSS compliance if any non-conformance condition defined in conformance.md §4 is present.
+*Source: §19*
+
+**LEBOSS-VER-4**
+A system MUST provide sufficient visibility into its governed operations to allow an independent party to verify conformance without relying solely on system-reported assertions.
+*Source: §19*
+
+**LEBOSS-VER-5**
+Where conformance levels are defined, those levels MUST be clearly bounded and non-ambiguous. A system MUST NOT represent partial satisfaction of a conformance level as meeting that level.
+*Source: §19*
+
+**LEBOSS-VER-6**
+Verification MUST NOT be satisfied by documentation, policy declaration, or stated intent alone. Conformance requires observable evidence of enforcement in governed operations.
+*Source: §19*
+
+---
+
 ## Summary Counts
 
 | Group | Rules | MUST | MUST NOT | MAY | SHOULD |
@@ -385,7 +414,8 @@ Delegation MUST NOT create implicit or inherited access. Access authorized throu
 | Data Portability Requirements (PORT) | 6 | 5  | 1  | — | — |
 | Cross-System Identity and Mapping (MAP) | 6 | 5  | 1  | — | — |
 | Delegation and Authority Chains (DEL)   | 6 | 3  | 3  | — | — |
-| **Total**                           | **70** | **49** | **22** | **5** | **—** |
+| Conformance Verification (VER)          | 6 | 4  | 4  | — | — |
+| **Total**                           | **76** | **53** | **26** | **5** | **—** |
 
 ---
 
@@ -410,4 +440,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.18. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.19. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.18
+**Updated Through:** proposal/0.0.19
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -751,4 +751,25 @@ The normative rules for delegation and authority chains (LEBOSS-DEL-1 through DE
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.18 — Open for community review and pull request contribution.*
+## 19. Conformance Verification
+
+The LEBOSS standard defines governance rules that must be satisfied in operation. The value of those rules depends on whether conformance can be meaningfully evaluated — whether a system's compliance claim can be independently examined, rather than accepted on assertion alone.
+
+Conformance is not a declaration; it is a demonstrable property of system behavior. A system satisfies LEBOSS conformance requirements when its governed operations can be observed to comply with applicable normative rules. Stating compliance is not the same as demonstrating it.
+
+This section establishes the structural requirements for conformance claims: what must be satisfiable, what constitutes sufficient visibility for independent review, and what conditions prevent a valid compliance claim.
+
+**Key behavioral requirements:**
+
+- A LEBOSS-compliant system **MUST** satisfy all applicable normative rules. Partial satisfaction of normative rules **MUST NOT** be represented as full compliance.
+- Compliance claims **MUST** be supportable through observable system behavior and audit records.
+- A system **MUST NOT** claim LEBOSS compliance if any non-conformance condition defined in §4 of the Conformance document is present.
+- A system **MUST** provide sufficient visibility into its governed operations to allow an independent party to verify conformance without relying solely on system-reported assertions.
+- Where conformance levels are defined, those levels **MUST** be clearly bounded and non-ambiguous. A system **MUST NOT** represent partial satisfaction of a conformance level as meeting that level.
+- Verification **MUST NOT** be satisfied by documentation, policy declaration, or stated intent alone. Conformance requires observable evidence of enforcement in governed operations.
+
+The normative rules for conformance verification (LEBOSS-VER-1 through VER-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.19 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Proposal 0.0.19 — Conformance Verification

Defines what it means for a LEBOSS conformance claim to be valid and independently verifiable. Adds the `VER` rule group (LEBOSS-VER-1 through VER-6) establishing that compliance must be demonstrable through observable system behavior, that partial compliance cannot be represented as full compliance, and that independent verification must be possible without relying on system-reported assertions alone.

## Changes

- `standards/leboss-standard.md` — Add §19 Conformance Verification (6 behavioral requirements)
- `standards/leboss-normative-rules.md` — Add VER rule group; rule count 70 → 76
- `standards/conformance.md` — Add §3.10; add non-conformance conditions 16–17
- `glossary/terms.md` — Add Conformance Claim and Conformance Evidence entries
- `proposals/0.0.19/proposal.md` — New proposal document

## Rule Count

70 → 76 (MUST: 49 → 53, MUST NOT: 22 → 26, MAY: 5 unchanged)

## Sequence

- 0.0.18 — delegation and authority chain constraints
- 0.0.19 — conformance verification requirements