### PR TITLE
feat(standard): normalize structure and eliminate cross-group redundancy (0.0.20)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.19
+**Updated Through:** proposal/0.0.20
 
 ---
 

--- a/proposals/0.0.20/proposal.md
+++ b/proposals/0.0.20/proposal.md
@@ -1,0 +1,88 @@
+# Proposal 0.0.20 — Structural Normalization
+
+**Status:** Draft
+**Target Version:** 0.0.20
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal improves the internal consistency, cross-reference accuracy, and terminology of the LEBOSS standard without changing its meaning. No new requirements are introduced. No existing requirements are removed. All changes are editorial or structural.
+
+---
+
+## Motivation
+
+Through proposals 0.0.13–0.0.19, the standard grew from 34 rules to 76 across thirteen rule groups, with four new protocol sections (§16–§19) added to the base standard. These additions introduced four categories of structural drift that this proposal resolves:
+
+1. **Stale version references** — `leboss-standard.md` retained "0.0.12" in three locations (preamble, preamble quotation block, §10 Versioning) after the standard was carried forward through 0.0.19.
+
+2. **Terminology inconsistency** — §5.4 dependency rules 4 and 5 used the pre-normalization term "root owner" while the rest of the standard uses "governing entity" (the term defined in the glossary and used throughout all other normative contexts).
+
+3. **Invalid rule cross-references in §14** — The Audit Record Collection Protocol mapping table referenced `LEBOSS-OBJ-AR-1`, `LEBOSS-OBJ-AR-3`, and `LEBOSS-OBJ-AR-4`. These are object-level rule identifiers from `standards/objects/audit-record.md` — they do not appear in the normative rule register (`leboss-normative-rules.md`) and are inconsistent with the register-based cross-reference convention used in §12 and §13. The overlapping register-level rules (`LEBOSS-REC-1`, `LEBOSS-REC-3`) are the correct references.
+
+4. **Misaligned rule cross-references in §15** — The Data Portability Protocol mapping table referenced `LEBOSS-CONT-1` through `CONT-4`. These are Continuity rules governing succession planning and operational resilience — not data portability protocol requirements. The PORT rules (`LEBOSS-PORT-1` through `PORT-6`), added in proposal 0.0.16 specifically to define data portability requirements, are the correct references. `LEBOSS-OWN-3` and `LEBOSS-SVC-1`/`SVC-2` are also applicable and were absent from the table.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Six targeted edits
+
+| Location | Change | Category |
+|----------|--------|----------|
+| Header | "Updated Through" → proposal/0.0.20 | Version stamp |
+| Preamble (body) | "proposals 0.0.1 through 0.0.12" → "0.0.1 through 0.0.20" | Stale reference |
+| Preamble (blockquote) | "proposals 0.0.1 through 0.0.12" → "0.0.1 through 0.0.20" | Stale reference |
+| §5.4 rules 4–5 | "root owner" → "governing entity" (2 instances) | Terminology |
+| §10 Versioning | "updated through proposal/0.0.12" → "0.0.20" | Stale reference |
+| §14 mapping table | Replace OBJ-AR-1, OBJ-AR-3, OBJ-AR-4 rows with REC-1, REC-3 | Cross-reference |
+| §15 mapping table | Replace CONT-1 through CONT-4 with OWN-3, SVC-1, SVC-2, PORT-1 through PORT-6 | Cross-reference |
+| Footer | "updated through proposal/0.0.19" → "0.0.20" | Version stamp |
+
+### 2. `standards/leboss-normative-rules.md`
+
+- Header and footer updated to proposal/0.0.20. No rule content changed.
+
+### 3. `standards/conformance.md`
+
+- Header updated to proposal/0.0.20. No conformance requirement changed.
+
+### 4. `glossary/terms.md`
+
+- Header updated to proposal/0.0.20. No definition changed.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Version reference corrections; terminology normalization; cross-reference alignment in §14 and §15 | Structural — no meaning change |
+| `standards/leboss-normative-rules.md` | Header/footer only | Version stamp |
+| `standards/conformance.md` | Header only | Version stamp |
+| `glossary/terms.md` | Header only | Version stamp |
+
+**Rule count:** 76 (unchanged)
+**MUST/MUST NOT/MAY counts:** unchanged
+
+---
+
+## Backward Compatibility
+
+This proposal introduces no new requirements and removes none. Systems conformant under 0.0.19 are conformant under 0.0.20 without modification. The §14 and §15 cross-reference corrections describe the same behavioral requirements — they correct which rule identifiers are cited as the basis for protocol sections, not the protocol requirements themselves.
+
+---
+
+## Sequence Context
+
+- 0.0.16 — defined PORT rules (LEBOSS-PORT-1 through PORT-6) for data portability
+- 0.0.17 — added §17 and MAP rules (cross-system resource identity and mapping)
+- 0.0.18 — added §18 and DEL rules (delegation and authority chains)
+- 0.0.19 — added §19 and VER rules (conformance verification)
+- 0.0.20 — structural normalization: terminology, version references, cross-references
+
+---
+
+*Proposal 0.0.20 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.19
+**Updated Through:** proposal/0.0.20
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.19
+**Updated Through:** proposal/0.0.20
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -440,4 +440,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.19. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.20. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.19
+**Updated Through:** proposal/0.0.20
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.12, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.20, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.12. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.20. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -356,8 +356,8 @@ The following dependency rules govern valid LEBOSS topologies. An implementation
 1. A backend service component **MUST** serve at least one customer interface. A backend with no associated interface has no purpose in the hierarchy.
 2. A customer interface **MUST** be supported by at least one backend service. An interface with no backend cannot deliver value.
 3. An internal capability component **MUST** operate within the data boundary of a single brand entity.
-4. An external integration component **MUST** be explicitly authorized at the brand entity or root owner level before it **MAY** receive any data.
-5. A brand entity **MUST** belong to exactly one root owner.
+4. An external integration component **MUST** be explicitly authorized at the brand entity or governing entity level before it **MAY** receive any data.
+5. A brand entity **MUST** belong to exactly one governing entity.
 6. A customer interface **MUST** belong to exactly one brand entity.
 
 ---
@@ -532,7 +532,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.12.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.20.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -643,9 +643,8 @@ The protocol operationalizes the following rules from this standard:
 | LEBOSS-SEC-3 — all data operations must be auditable | §3 Audit Event Capture |
 | LEBOSS-SVC-3 — service providers must maintain complete audit records | §3 Audit Event Capture, §5 Retention |
 | LEBOSS-SVC-4 — audit records must be available to the governing entity | §7 Audit Verification |
-| LEBOSS-OBJ-AR-1 — Audit Records must be created for every governed event | §3 Audit Event Capture |
-| LEBOSS-OBJ-AR-3 — Audit Records must not be modified after creation | §6 Integrity |
-| LEBOSS-OBJ-AR-4 — Audit Records must be retained for a minimum of 36 months | §5 Retention |
+| LEBOSS-REC-1 — Audit Records constitute the authoritative record of governed actions | §3 Audit Event Capture |
+| LEBOSS-REC-3 — Audit Records are foundational, not supplementary | §6 Integrity |
 
 **Key behavioral requirements:**
 
@@ -669,10 +668,15 @@ The protocol operationalizes the following rules from this standard:
 
 | Rule | Protocol Section |
 |------|-----------------|
-| LEBOSS-CONT-1 — governed systems must support data portability | §3 Export Authority, §4 Export Scope |
-| LEBOSS-CONT-2 — governing entities must be able to exit systems with their data | §3 Export Authority, §5 Export Completeness |
-| LEBOSS-CONT-3 — data must be exportable in a machine-readable format | §6 Export Neutrality |
-| LEBOSS-CONT-4 — export obligations survive contract termination | §5 Export Completeness, §7 Migration Considerations |
+| LEBOSS-OWN-3 — governing entity must be able to export all primary operational data at any time | §3 Export Authority |
+| LEBOSS-SVC-1 — provider must facilitate complete export upon service termination | §3 Export Authority, §5 Export Completeness |
+| LEBOSS-SVC-2 — provider must not withhold, delay, or degrade an export | §5 Export Completeness |
+| LEBOSS-PORT-1 — complete export must include all primary operational data, governance objects, and audit records | §4 Export Scope, §5 Export Completeness |
+| LEBOSS-PORT-2 — export must not omit any governed resource category without authorization | §5 Export Completeness |
+| LEBOSS-PORT-3 — export must preserve structural relationships | §5 Export Completeness |
+| LEBOSS-PORT-4 — export must be sufficient to reconstruct the governed environment independently | §6 Export Neutrality |
+| LEBOSS-PORT-5 — exports must use documented, non-proprietary formats | §6 Export Neutrality |
+| LEBOSS-PORT-6 — exports must include a manifest for independent completeness verification | §5 Export Completeness |
 
 **Key behavioral requirements:**
 
@@ -772,4 +776,4 @@ The normative rules for conformance verification (LEBOSS-VER-1 through VER-6) ar
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.19 — Open for community review and pull request contribution.*
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.20 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Structural normalization pass — no new requirements, no removed requirements, no meaning changes. Rule count remains 76.

- **Three stale version references** in `leboss-standard.md` corrected from 0.0.12 to 0.0.20 (preamble body, preamble blockquote, §10 Versioning)
- **Terminology normalized** in §5.4 dependency rules 4 and 5: "root owner" → "governing entity" (consistent with all other normative contexts and the glossary definition)
- **§14 cross-references corrected**: removed `LEBOSS-OBJ-AR-1`, `OBJ-AR-3`, `OBJ-AR-4` from the Audit Record Collection Protocol mapping table — these are object-level rule IDs absent from the normative register; replaced with `LEBOSS-REC-1` and `LEBOSS-REC-3`, which are the correct register-level equivalents
- **§15 cross-references corrected**: replaced `LEBOSS-CONT-1` through `CONT-4` in the Data Portability Protocol mapping table with `LEBOSS-OWN-3`, `SVC-1`, `SVC-2`, and `PORT-1` through `PORT-6` — the CONT rules govern succession and continuity, not portability protocol requirements; the PORT rules were added in 0.0.16 specifically for this purpose

## Test plan

- [ ] No normative rule text modified in `leboss-normative-rules.md`
- [ ] No conformance requirement modified in `conformance.md`
- [ ] No glossary definition modified in `glossary/terms.md`
- [ ] Rule count remains 76 (MUST: 53, MUST NOT: 26, MAY: 5)
- [ ] All `LEBOSS-OBJ-AR-*` references removed from base standard
- [ ] §15 table references only register-level rule IDs (OWN, SVC, PORT)
- [ ] "root owner" no longer appears in normative contexts in `leboss-standard.md`
- [ ] All version references updated to 0.0.20