### PR TITLE
feat(standard): define service provider boundary and obligations (0.0.23)

### DIFF
--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.22
+**Updated Through:** proposal/0.0.23
 
 ---
 
@@ -674,7 +674,15 @@ The third of LEBOSS's five Foundation Principles. Security requires that data be
 
 ## Service Provider
 
-Any individual or organization that builds, manages, or operates systems on behalf of a local business under the LEBOSS framework. Service providers are stewards of business data, not owners. They must operate within explicitly granted access, maintain audit records, and facilitate data portability upon exit.
+Any entity that stores, processes, transmits, or has the ability to access or control primary operational data on behalf of the governing entity. Service providers include, but are not limited to: application developers, platform operators, managed service providers, and entities providing infrastructure, hosting, or administrative support to systems containing primary operational data — regardless of whether their access is direct, delegated, purposeful, or incidental.
+
+An entity does not become exempt from LEBOSS obligations by characterizing its role as infrastructure, utilities, or support. The governing criterion is the ability to access or control primary operational data, not the label applied to the relationship.
+
+Service providers are stewards of business data, not owners. They must operate within explicitly granted Access Grants, disclose subprocessors, maintain audit records, and facilitate data portability upon exit.
+
+Normative rules: LEBOSS-SVC-1 through SVC-9, LEBOSS-ACC-1.
+
+See also: *Subprocessor*, *Access Grant*, *Governing Entity*, *Steward*
 
 ---
 
@@ -716,7 +724,9 @@ See also: *Implementation*, *Conformance*, *Reference Model*
 
 ## Subprocessor
 
-A third-party service used by a service provider that has access to primary operational data. Subprocessors must be disclosed to the governing entity and are subject to the same LEBOSS obligations as the primary service provider.
+A third-party entity used by a service provider that has the ability to access primary operational data — including entities providing infrastructure, hosting, or administrative support to systems containing primary operational data. A subprocessor is a service provider under this standard (LEBOSS-SVC-8) and must be disclosed to the governing entity (LEBOSS-SVC-5). Subprocessors are subject to the same LEBOSS service provider obligations as the primary service provider (LEBOSS-SVC-6).
+
+See also: *Service Provider*, *Access Grant*, *Governing Entity*
 
 ---
 

--- a/proposals/0.0.23/proposal.md
+++ b/proposals/0.0.23/proposal.md
@@ -1,0 +1,113 @@
+# Proposal 0.0.23 — Service Provider Boundary
+
+**Status:** Draft
+**Target Version:** 0.0.23
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`, `glossary/terms.md`
+
+---
+
+## Summary
+
+This proposal defines what constitutes a service provider under the LEBOSS standard, closing an exploitable gap identified in the 0.0.21 boundary stress test (Scenario 6: "The Disclosed But Uncontrolled Subprocessor Chain").
+
+The prior standard used "service provider" in over twenty normative rules — including the access grant requirement (ACC-1) and subprocessor disclosure requirement (SVC-5) — without defining the term. This allowed a primary service provider to engage infrastructure operators with physical access to primary operational data and argue those entities were not "service providers" under the standard, therefore not subject to disclosure or access grant requirements.
+
+The fix defines service provider functionally: any entity with the ability to access or control primary operational data is a service provider, regardless of what label is applied to their role. Two new normative rules enforce this definition and close the ungoverned-access loophole.
+
+---
+
+## Motivation
+
+The 0.0.21 stress test (Scenario 6) demonstrated:
+
+1. Provider A discloses subprocessors B, C, D — all of which they directly engage.
+2. Provider B operates on cloud infrastructure from Provider E, whose staff have administrative access to servers containing primary operational data.
+3. Provider A argues E is "infrastructure" and not a "subprocessor" subject to SVC-5.
+4. Provider E has no Access Grant from the governing entity and no disclosure obligation under the narrow interpretation.
+5. E's staff can access primary operational data with no governance coverage.
+
+The root cause: "service provider" was undefined. ACC-1 prohibits access without an explicit Access Grant — but "service provider" didn't clearly include infrastructure operators. SVC-5 requires disclosure of "third-party services that have access" — but "access" was interpreted as purposeful application-level access, excluding administrative or incidental access.
+
+With over twenty normative rules depending on the meaning of "service provider," the definitional gap propagated through the entire access control model.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-standard.md` — Add §7.0 Service Provider Definition
+
+Adds a new sub-section before §7.1 establishing:
+
+- A service provider is any entity that stores, processes, transmits, or has the ability to access or control primary operational data, including entities providing infrastructure, hosting, or administrative support
+- The governing criterion is ability to access or control, not role label
+- A MUST NOT rule: no entity may access primary operational data without being subject to service provider obligations
+
+**Also updated:** all version stamps (0.0.22 → 0.0.23).
+
+### 2. `standards/leboss-normative-rules.md` — Add SVC-8 and SVC-9
+
+**LEBOSS-SVC-8** (MUST): Any entity that stores, processes, transmits, or has the ability to access or control primary operational data — including entities providing infrastructure, hosting, or administrative support to systems containing primary operational data — MUST be treated as a service provider and is subject to all applicable service provider obligations, regardless of whether their access is direct, delegated, purposeful, or incidental.
+
+**LEBOSS-SVC-9** (MUST NOT): A conformant system MUST NOT permit any entity to access primary operational data without that entity being subject to the service provider obligations defined in this standard, including disclosure requirements (LEBOSS-SVC-5) and access grant requirements (LEBOSS-ACC-1).
+
+Rule count: 78 → 80. SVC group: 7 → 9 rules, MUST 5 → 6, MUST NOT 2 → 3. Total MUST: 54 → 55, MUST NOT: 27 → 28.
+
+Header and footer updated to proposal/0.0.23.
+
+### 3. `standards/conformance.md` — Add condition 19
+
+**Condition 19 — Ungoverned infrastructure access:** any entity with the ability to access or control systems containing primary operational data is not treated as a service provider, is not disclosed to the governing entity, or is not subject to the service provider obligations and access grant requirements of this standard (LEBOSS-SVC-8, LEBOSS-SVC-9).
+
+Header updated to proposal/0.0.23.
+
+### 4. `glossary/terms.md` — Rewrite Service Provider and Subprocessor
+
+**Service Provider:** Rewritten with functional definition. Any entity with the ability to access or control primary operational data is a service provider. Explicitly includes infrastructure, hosting, and administrative support entities. States that role label does not create exemption. Adds normative rule citations (SVC-1 through SVC-9, ACC-1).
+
+**Subprocessor:** Updated to state explicitly that a subprocessor is a service provider under this standard (LEBOSS-SVC-8), not merely an entity "subject to the same obligations." This closes the interpretation gap where a subprocessor could be treated as categorically different from a service provider.
+
+Header updated to proposal/0.0.23.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-standard.md` | Add §7.0 with definition and MUST NOT rule; version stamps | Normative addition — closes definitional gap |
+| `standards/leboss-normative-rules.md` | Add SVC-8, SVC-9; rule count 78 → 80 | Normative addition |
+| `standards/conformance.md` | Add condition 19 | Normative addition |
+| `glossary/terms.md` | Rewrite Service Provider and Subprocessor | Normative clarification |
+
+**Rule count:** 78 → 80
+**MUST count:** 54 → 55 (SVC-8 adds 1 MUST)
+**MUST NOT count:** 27 → 28 (SVC-9 adds 1 MUST NOT)
+**MAY count:** 5 (unchanged)
+
+---
+
+## Downstream Effect of SVC-8
+
+Because over twenty prior rules depend on the term "service provider" — including ACC-1 (access grant requirement), SVC-5 (disclosure), SVC-3/4 (audit records), SVC-7 (no secondary use) — the new definition extends all of these obligations to infrastructure providers with access capability. No prior rules need to be amended; SVC-8 expands their reach by expanding the definition of who they apply to.
+
+---
+
+## Backward Compatibility
+
+Systems where infrastructure operators already operate under disclosed and governed relationships are unaffected. Systems where infrastructure operators were treated as outside the governance model may now be required to:
+- Disclose infrastructure providers with access capability (SVC-5, SVC-8)
+- Ensure those providers operate under Access Grant coverage (ACC-1, SVC-9)
+
+This is intentional. The prior state allowed exactly the data access path LEBOSS is designed to prevent.
+
+---
+
+## Sequence Context
+
+- 0.0.21 — Stress test; Scenario 6 identified the undefined "service provider" gap
+- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
+- 0.0.23 — Closes service provider boundary (SVC-8, SVC-9)
+
+---
+
+*Proposal 0.0.23 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.22
+**Updated Through:** proposal/0.0.23
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -224,6 +224,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 17. **Unverifiable conformance** — the system does not provide sufficient visibility into its governed operations to allow an independent party to verify conformance, or represents partial satisfaction of normative rules as full compliance (LEBOSS-VER-2, LEBOSS-VER-4, LEBOSS-VER-5, LEBOSS-VER-6).
 
 18. **Functionally incomplete export** — the system applies a definition of primary operational data narrow enough to exclude data materially required for continuity, accountability, or reconstruction of the governed environment, producing exports that satisfy structural completeness requirements while omitting business-critical operational content (LEBOSS-OWN-10, LEBOSS-PORT-1).
+
+19. **Ungoverned infrastructure access** — any entity with the ability to access or control systems containing primary operational data is not treated as a service provider, is not disclosed to the governing entity, or is not subject to the service provider obligations and access grant requirements of this standard (LEBOSS-SVC-8, LEBOSS-SVC-9).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.22
+**Updated Through:** proposal/0.0.23
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -224,6 +224,14 @@ Disclosed subprocessors are subject to the same LEBOSS requirements as the prima
 The service provider MUST NOT use primary operational data for any purpose beyond delivering the contracted service — including training machine learning models, building aggregate datasets, or improving services for other customers — without explicit written consent from the governing entity.
 *Source: §7.6*
 
+**LEBOSS-SVC-8**
+Any entity that stores, processes, transmits, or has the ability to access or control primary operational data — including entities providing infrastructure, hosting, or administrative support to systems containing primary operational data — MUST be treated as a service provider under this standard and is subject to all applicable service provider obligations, regardless of whether their access is direct, delegated, purposeful, or incidental.
+*Source: §7.0*
+
+**LEBOSS-SVC-9**
+A conformant system MUST NOT permit any entity to access primary operational data without that entity being subject to the service provider obligations defined in this standard, including disclosure requirements (LEBOSS-SVC-5) and access grant requirements (LEBOSS-ACC-1).
+*Source: §7.0*
+
 ---
 
 ## Specification Boundary Rules
@@ -415,7 +423,7 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Architectural (ARCH) | 11 | 9 | 2 | — | — |
 | Security (SEC) | 5 | 4 | 1 | 1 | — |
 | Continuity (CONT) | 4 | 4 | 1 | — | — |
-| Service Provider (SVC)              | 7  | 5  | 2  | — | — |
+| Service Provider (SVC)              | 9  | 6  | 3  | — | — |
 | Specification Boundary (SPEC)       | 4  | 2  | 2  | 1 | — |
 | Enforcement Responsibility (ENF)    | 4  | 2  | 3  | — | — |
 | Audit as System of Record (REC)     | 4  | 2  | 2  | — | — |
@@ -423,7 +431,7 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Cross-System Identity and Mapping (MAP) | 6 | 5  | 1  | — | — |
 | Delegation and Authority Chains (DEL)   | 6 | 3  | 3  | — | — |
 | Conformance Verification (VER)          | 6 | 4  | 4  | — | — |
-| **Total**                           | **78** | **54** | **27** | **5** | **—** |
+| **Total**                           | **80** | **55** | **28** | **5** | **—** |
 
 ---
 
@@ -448,4 +456,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.22. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.23. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.22
+**Updated Through:** proposal/0.0.23
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.22, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.23, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.22. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.23. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -432,7 +432,15 @@ The governing entity retains the right to require that data reside within specif
 
 ## 7. Service Provider Responsibilities
 
-A service provider operating within a LEBOSS-compliant ecosystem — whether building a customer interface, managing a backend service, operating an internal capability, or connecting an external integration — accepts the following responsibilities.
+### 7.0 Service Provider Definition
+
+A **service provider** under this standard is any entity that stores, processes, transmits, or has the ability to access or control primary operational data on behalf of the governing entity. This includes entities providing infrastructure, hosting, or administrative support to systems containing primary operational data, regardless of whether their access is direct, delegated, purposeful, or incidental.
+
+An entity does not become exempt from this standard's obligations by characterizing its role as infrastructure, utilities, or support. The governing criterion is the ability to access or control primary operational data — not the label applied to the relationship.
+
+A conformant system **MUST NOT** permit any entity to access primary operational data without that entity being subject to the service provider obligations defined in this standard, including disclosure requirements and access grant requirements.
+
+The responsibilities in this section apply to all service providers so defined.
 
 ### 7.1 Act as Steward, Not Owner
 
@@ -537,7 +545,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.22.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.23.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -781,4 +789,4 @@ The normative rules for conformance verification (LEBOSS-VER-1 through VER-6) ar
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.22 — Open for community review and pull request contribution.*
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.23 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Closes the **\"ungoverned infrastructure access\" loophole** identified in the 0.0.21 boundary stress test (Scenario 6: \"The Disclosed But Uncontrolled Subprocessor Chain\").

The prior standard used \"service provider\" in over 20 normative rules — including the access grant requirement (ACC-1) and subprocessor disclosure requirement (SVC-5) — without defining the term. This allowed infrastructure operators with physical/administrative access to primary operational data to claim exemption from governance obligations.

**Changes:**
- `§7.0` (new): Functional definition — a service provider is any entity with the ability to access or control primary operational data, including infrastructure, hosting, and administrative support entities; role label does not create exemption
- `§7.0`: MUST NOT rule — no entity may access primary operational data without being subject to service provider obligations
- `leboss-normative-rules.md`: Add LEBOSS-SVC-8 (functional definition, MUST) and LEBOSS-SVC-9 (ungoverned access prohibited, MUST NOT); rule count 78 → 80
- `conformance.md`: Add condition 19 — Ungoverned infrastructure access
- `glossary/terms.md`: Rewrite Service Provider with functional definition + rule citations; update Subprocessor to explicitly classify as a service provider under SVC-8

## Test plan
- [ ] Verify §7.0 definition is implementation-agnostic (no cloud models, no technical mechanisms)
- [ ] Verify SVC-8 and SVC-9 are in the normative rules register with correct source citations (§7.0)
- [ ] Verify rule count table: SVC 7→9, MUST 54→55, MUST NOT 27→28, Total 78→80
- [ ] Verify conformance.md condition 19 cites LEBOSS-SVC-8 and LEBOSS-SVC-9
- [ ] Verify Service Provider glossary entry includes infrastructure/hosting entities and cites SVC-1 through SVC-9
- [ ] Verify Subprocessor glossary entry classifies subprocessors as service providers under SVC-8
- [ ] Verify all version stamps updated from 0.0.22 to 0.0.23
- [ ] Verify no prior SVC, ACC, OWN, or PORT rules are weakened