### PR TITLE
feat(standard): align protocol requirements with normative rule register (0.0.24)

### DIFF
--- a/proposals/0.0.24/proposal.md
+++ b/proposals/0.0.24/proposal.md
@@ -1,0 +1,117 @@
+# Proposal 0.0.24 — Protocol Normativity Alignment
+
+**Status:** Draft
+**Target Version:** 0.0.24
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`
+
+---
+
+## Summary
+
+This proposal closes a structural gap identified in the 0.0.21 boundary stress test: behavioral requirements defined in LEBOSS protocol documents had no formal normative standing within the rule register. A system could satisfy all 80 register-level rules while violating protocol behavioral requirements (LEBOSS-AGP-*, LEBOSS-ACP-*, LEBOSS-IDP-*, LEBOSS-DPP-*) and not be detectable as non-conformant through rule register evaluation alone.
+
+The fix is minimal: a new rule group, `PROT`, establishes that protocol documents are normative extensions of the standard, not informative supplements. Five rules (PROT-1 through PROT-5) formally incorporate the four protocol documents into the normative framework by reference, making their MUST and MUST NOT requirements binding without re-listing each rule in the register. A new non-conformance condition (condition 20) makes protocol-only compliance a detectable conformance failure.
+
+---
+
+## Motivation
+
+The LEBOSS standard defines behavioral requirements across two artifact types:
+
+1. **The normative rule register** (`leboss-normative-rules.md`) — flat, enumerable rules used as the primary conformance checklist
+2. **Protocol documents** — detailed behavioral specifications defining what systems must do when executing access grant lifecycle events, audit record capture, integration state transitions, and data export operations
+
+The protocol documents contain ~75 normative requirements (LEBOSS-AGP-1 through AGP-17, LEBOSS-IDP-1 through IDP-26, LEBOSS-ACP-1 through ACP-24, LEBOSS-DPP-1 through DPP-28). These requirements are expressed with the same MUST/MUST NOT language as register rules — but the register did not formally incorporate them. The Gaps section of the register acknowledged the protocols existed, but treated them as supplementary resolutions rather than normative extensions.
+
+**The exploitable condition:** A conformance evaluator relying solely on the rule register could find a system compliant while that system deferred audit record creation, cached revocation status, or misrepresented partial exports as complete — all of which are protocol violations but have no direct representation in the register.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-normative-rules.md` — Add PROT group and update Gaps
+
+**New rule group: PROT — Protocol Normativity Rules** (5 rules)
+
+- **LEBOSS-PROT-1** (MUST): Formally incorporates the four protocol documents into the normative framework by reference, listing each document and its rule range. A compliant system must satisfy all incorporated protocol rules.
+- **LEBOSS-PROT-2** (MUST NOT): Protocol-level MUST/MUST NOT requirements must not be treated as non-binding guidance. They carry the same normative weight as register rules.
+- **LEBOSS-PROT-3** (MUST NOT): Conformance evaluation must not be performed against the register alone while ignoring incorporated protocol documents.
+- **LEBOSS-PROT-4** (MUST NOT): Incorporated protocol documents must not introduce enforceable requirements disconnected from the standard's governance framework.
+- **LEBOSS-PROT-5** (MUST): Incorporation under PROT-1 makes a protocol rule normatively binding without requiring separate listing in the register.
+
+**Summary counts updated:** 80 → 85 rules. MUST: 55 → 57. MUST NOT: 28 → 31. MAY: 5 (unchanged).
+
+**Gaps section updated:** GAP-1 through GAP-4 updated to note normative standing formalized in 0.0.24 under LEBOSS-PROT-1. GAP-3 updated to reflect DPP behavioral requirements fully incorporated (canonical encoding format remains deferred).
+
+**Header updated:** proposal/0.0.23 → proposal/0.0.24.
+
+### 2. `standards/leboss-standard.md` — Add §20 Protocol Normativity Framework
+
+New section establishes the two-tier normative structure:
+
+- **Tier 1**: The rule register — flat enumerable rules
+- **Tier 2**: Incorporated protocol documents — normative extensions operationalizing Tier 1 rules
+
+Section includes the incorporation table listing all four protocol documents and their rule ranges, key behavioral requirements (citing PROT-1 through PROT-5), and cross-reference to the rule register.
+
+**ToC updated:** Entries for §17–§20 added (§17–§19 were present but not listed in the original ToC).
+
+**Version stamps updated:** proposal/0.0.23 → proposal/0.0.24 throughout.
+
+### 3. `standards/conformance.md` — Add condition 20
+
+**Condition 20 — Protocol-only compliance:** the system satisfies register-level normative rules while failing to satisfy behavioral requirements defined in incorporated LEBOSS protocol documents, or treats protocol-level MUST and MUST NOT requirements as non-binding guidance rather than normative obligations (LEBOSS-PROT-1, LEBOSS-PROT-2, LEBOSS-PROT-3).
+
+**Header updated:** proposal/0.0.23 → proposal/0.0.24.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-normative-rules.md` | Add PROT group (5 rules); update summary counts; update Gaps section | Normative addition — formalizes protocol incorporation |
+| `standards/leboss-standard.md` | Add §20; update ToC; update version stamps | Normative addition |
+| `standards/conformance.md` | Add condition 20; update header | Normative addition |
+
+**Rule count:** 80 → 85
+**MUST count:** 55 → 57 (PROT-1, PROT-5 add 2 MUSTs)
+**MUST NOT count:** 28 → 31 (PROT-2, PROT-3, PROT-4 add 3 MUST NOTs)
+**MAY count:** 5 (unchanged)
+
+---
+
+## No New Behavioral Requirements
+
+This proposal introduces no new behavioral requirements. The protocol rules it incorporates (AGP-1 through AGP-17, IDP-1 through IDP-26, ACP-1 through ACP-24, DPP-1 through DPP-28) existed prior to this proposal. PROT-1 through PROT-5 govern the normative standing of those existing rules — they do not define new obligations for governed systems, only for the standard itself and for conformance evaluation.
+
+---
+
+## Downstream Effect of PROT Group
+
+The five PROT rules extend the reach of conformance evaluation to the full set of protocol behavioral requirements without requiring those requirements to be re-listed. A conformance evaluator who previously could ignore protocol documents while checking the register is now in violation of PROT-3 if they do so. Non-conformance condition 20 makes this a disqualifying condition for a LEBOSS-compliant claim.
+
+---
+
+## Backward Compatibility
+
+Systems already satisfying protocol behavioral requirements are unaffected. Systems that treated protocol documents as informative rather than normative may now be required to:
+- Satisfy the full set of access grant lifecycle rules (AGP-1 through AGP-17)
+- Satisfy the full set of audit capture, retention, and integrity rules (ACP-1 through ACP-24)
+- Satisfy the full set of integration lifecycle rules (IDP-1 through IDP-26)
+- Satisfy the full set of export authority, completeness, and neutrality rules (DPP-1 through DPP-28)
+
+This is intentional. The prior state allowed a system to claim compliance based on register evaluation while silently omitting protocol enforcement.
+
+---
+
+## Sequence Context
+
+- 0.0.21 — Stress test; identified protocol normativity gap
+- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
+- 0.0.23 — Closed service provider boundary (SVC-8, SVC-9)
+- 0.0.24 — Aligns protocol requirements with normative rule register (PROT-1 through PROT-5)
+
+---
+
+*Proposal 0.0.24 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.23
+**Updated Through:** proposal/0.0.24
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -226,6 +226,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 18. **Functionally incomplete export** — the system applies a definition of primary operational data narrow enough to exclude data materially required for continuity, accountability, or reconstruction of the governed environment, producing exports that satisfy structural completeness requirements while omitting business-critical operational content (LEBOSS-OWN-10, LEBOSS-PORT-1).
 
 19. **Ungoverned infrastructure access** — any entity with the ability to access or control systems containing primary operational data is not treated as a service provider, is not disclosed to the governing entity, or is not subject to the service provider obligations and access grant requirements of this standard (LEBOSS-SVC-8, LEBOSS-SVC-9).
+
+20. **Protocol-only compliance** — the system satisfies register-level normative rules while failing to satisfy behavioral requirements defined in incorporated LEBOSS protocol documents (LEBOSS-AGP-1 through AGP-17, LEBOSS-IDP-1 through IDP-26, LEBOSS-ACP-1 through ACP-24, LEBOSS-DPP-1 through DPP-28), or treats protocol-level MUST and MUST NOT requirements as non-binding guidance rather than normative obligations (LEBOSS-PROT-1, LEBOSS-PROT-2, LEBOSS-PROT-3).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -440,7 +440,7 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 ## Protocol Normativity Rules
 
 **LEBOSS-PROT-1**
-All normative behavioral requirements defined in LEBOSS protocol documents are normative requirements of this standard. The following protocol documents are incorporated into the normative framework of this standard: the Access Grant Protocol (`standards/leboss-access-grant-protocol.md`, LEBOSS-AGP-1 through AGP-17), the Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`, LEBOSS-IDP-1 through IDP-26), the Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`, LEBOSS-ACP-1 through ACP-24), and the Data Portability Protocol (`standards/leboss-data-portability-protocol.md`, LEBOSS-DPP-1 through DPP-28). A system claiming LEBOSS compliance MUST satisfy the behavioral requirements of all incorporated protocol documents.
+The following protocol documents are incorporated into the normative framework of this standard: the Access Grant Protocol (`standards/leboss-access-grant-protocol.md`, LEBOSS-AGP-1 through AGP-17), the Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`, LEBOSS-IDP-1 through IDP-26), the Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`, LEBOSS-ACP-1 through ACP-24), and the Data Portability Protocol (`standards/leboss-data-portability-protocol.md`, LEBOSS-DPP-1 through DPP-28). A system claiming LEBOSS compliance MUST satisfy the requirements of all incorporated protocol documents. Only protocol provisions expressed in normative language (MUST, MUST NOT, SHALL) are incorporated as binding requirements under this rule. Explanatory, descriptive, or non-normative content in protocol documents is not binding.
 *Source: §20*
 
 **LEBOSS-PROT-2**
@@ -452,7 +452,7 @@ Conformance evaluation MUST NOT be performed against this register alone while i
 *Source: §20*
 
 **LEBOSS-PROT-4**
-Protocol documents incorporated into this standard MUST NOT introduce enforceable behavioral requirements that are not traceable to this standard's governance framework. Protocol rules must extend or operationalize requirements within defined rule groups; they MUST NOT create obligations disconnected from the standard's established normative structure.
+Incorporated protocol documents MUST NOT introduce normative requirements that are not traceable to the governance model defined in this standard. A protocol provision is traceable if it operationalizes a requirement within an established rule group or directly enforces a principle, doctrine, or obligation defined in this standard.
 *Source: §20*
 
 **LEBOSS-PROT-5**

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.23
+**Updated Through:** proposal/0.0.24
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -31,6 +31,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `MAP` — Cross-System Resource Identity and Mapping Rules
 - `DEL` — Delegation and Authority Chain Rules
 - `VER` — Conformance Verification Rules
+- `PROT` — Protocol Normativity Rules
 
 ---
 
@@ -431,29 +432,54 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Cross-System Identity and Mapping (MAP) | 6 | 5  | 1  | — | — |
 | Delegation and Authority Chains (DEL)   | 6 | 3  | 3  | — | — |
 | Conformance Verification (VER)          | 6 | 4  | 4  | — | — |
-| **Total**                           | **80** | **55** | **28** | **5** | **—** |
+| Protocol Normativity (PROT)             | 5 | 2  | 3  | — | — |
+| **Total**                           | **85** | **57** | **31** | **5** | **—** |
+
+---
+
+## Protocol Normativity Rules
+
+**LEBOSS-PROT-1**
+All normative behavioral requirements defined in LEBOSS protocol documents are normative requirements of this standard. The following protocol documents are incorporated into the normative framework of this standard: the Access Grant Protocol (`standards/leboss-access-grant-protocol.md`, LEBOSS-AGP-1 through AGP-17), the Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`, LEBOSS-IDP-1 through IDP-26), the Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`, LEBOSS-ACP-1 through ACP-24), and the Data Portability Protocol (`standards/leboss-data-portability-protocol.md`, LEBOSS-DPP-1 through DPP-28). A system claiming LEBOSS compliance MUST satisfy the behavioral requirements of all incorporated protocol documents.
+*Source: §20*
+
+**LEBOSS-PROT-2**
+A conformant system MUST NOT treat protocol-level behavioral rules as non-binding guidance. A MUST or MUST NOT requirement defined in an incorporated LEBOSS protocol document carries the same normative weight as a rule listed directly in this register.
+*Source: §20*
+
+**LEBOSS-PROT-3**
+Conformance evaluation MUST NOT be performed against this register alone while ignoring behavioral requirements defined in incorporated protocol documents. Full conformance requires satisfaction of all register rules and all applicable protocol-level rules.
+*Source: §20*
+
+**LEBOSS-PROT-4**
+Protocol documents incorporated into this standard MUST NOT introduce enforceable behavioral requirements that are not traceable to this standard's governance framework. Protocol rules must extend or operationalize requirements within defined rule groups; they MUST NOT create obligations disconnected from the standard's established normative structure.
+*Source: §20*
+
+**LEBOSS-PROT-5**
+Where an incorporated LEBOSS protocol defines required behavior through MUST or MUST NOT language, that requirement MUST be treated as normatively binding by virtue of the protocol's incorporation under LEBOSS-PROT-1. No separate rule listing in this register is required for a protocol rule to constitute a binding obligation under this standard.
+*Source: §20*
 
 ---
 
 ## Gaps Identified
 
-The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.12.
+The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.24.
 
-**GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4*
-The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17).
+**GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4; normative standing formalized in 0.0.24*
+The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
 
-**GAP-2: Audit Trail Format** — *Resolved in 0.0.3 and 0.0.6*
-The standard requires auditable records (LEBOSS-SEC-3, LEBOSS-SVC-3). The Audit Record object (`standards/objects/audit-record.md`) defines the required fields. The Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`) defines capture, correlation, retention, and integrity behavioral rules (LEBOSS-ACP-1 through ACP-24).
+**GAP-2: Audit Trail Format** — *Resolved in 0.0.3 and 0.0.6; normative standing formalized in 0.0.24*
+The standard requires auditable records (LEBOSS-SEC-3, LEBOSS-SVC-3). The Audit Record object (`standards/objects/audit-record.md`) defines the required fields. The Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`) defines capture, correlation, retention, and integrity behavioral rules (LEBOSS-ACP-1 through ACP-24). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
 
-**GAP-3: Portability Format** — *Partially resolved — export requirements defined; canonical encoding remains deferred*
-The standard requires machine-readable export (LEBOSS-OWN-3, LEBOSS-SVC-1). The Data Portability Protocol (`standards/leboss-data-portability-protocol.md`) defines export authority, scope, completeness, and neutrality behavioral rules (LEBOSS-DPP-1 through DPP-28). Proposal 0.0.16 added standard-level requirements for export completeness, relationship preservation, reconstructability, format independence, and manifests (LEBOSS-PORT-1 through PORT-6). A specific canonical encoding format remains deferred to a future proposal.
+**GAP-3: Portability Format** — *Portability behavioral requirements resolved; canonical encoding deferred*
+The standard requires machine-readable export (LEBOSS-OWN-3, LEBOSS-SVC-1). The Data Portability Protocol (`standards/leboss-data-portability-protocol.md`) defines export authority, scope, completeness, and neutrality behavioral rules (LEBOSS-DPP-1 through DPP-28). Proposal 0.0.16 added standard-level requirements for export completeness, relationship preservation, reconstructability, format independence, and manifests (LEBOSS-PORT-1 through PORT-6). DPP behavioral rules are incorporated as normative requirements under LEBOSS-PROT-1. A specific canonical encoding format remains deferred to a future proposal.
 
-**GAP-4: External Integration Authorization Protocol** — *Resolved in 0.0.3 and 0.0.5*
-LEBOSS-ACC-5 requires explicit authorization for external integrations. The Integration Descriptor object (`standards/objects/integration-descriptor.md`) defines what must be recorded. The Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`) defines the full integration lifecycle and behavioral rules (LEBOSS-IDP-1 through IDP-26).
+**GAP-4: External Integration Authorization Protocol** — *Resolved in 0.0.3 and 0.0.5; normative standing formalized in 0.0.24*
+LEBOSS-ACC-5 requires explicit authorization for external integrations. The Integration Descriptor object (`standards/objects/integration-descriptor.md`) defines what must be recorded. The Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`) defines the full integration lifecycle and behavioral rules (LEBOSS-IDP-1 through IDP-26). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
 
 **GAP-5: Succession and Ownership Transfer** — *Open*
 LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists for executing an ownership transfer. Deferred to a future proposal.
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.23. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.24. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -803,7 +803,7 @@ The LEBOSS standard defines normative requirements across two tiers.
 
 A system that satisfies register-level rules while violating protocol-level behavioral requirements is not conformant. A system that claims conformance by interpreting protocol documents as informative guidance does not satisfy this standard.
 
-The following protocol documents are incorporated into the normative framework of this standard:
+The following protocol documents are incorporated into the normative framework of this standard. Only provisions expressed in normative language (MUST, MUST NOT, SHALL) are incorporated as binding requirements. Explanatory, descriptive, or non-normative content in protocol documents is not binding.
 
 | Protocol Document | Incorporated Rules |
 |------------------|--------------------|
@@ -814,10 +814,10 @@ The following protocol documents are incorporated into the normative framework o
 
 **Key behavioral requirements:**
 
-- A system claiming LEBOSS compliance **MUST** satisfy the behavioral requirements of all incorporated protocol documents (LEBOSS-PROT-1).
+- A system claiming LEBOSS compliance **MUST** satisfy all normative provisions of the incorporated protocol documents (LEBOSS-PROT-1).
 - Protocol-level MUST and MUST NOT requirements **MUST NOT** be treated as non-binding guidance (LEBOSS-PROT-2).
-- Conformance evaluation **MUST NOT** be limited to register rules while ignoring applicable protocol-level behavioral requirements (LEBOSS-PROT-3).
-- Incorporated protocol documents **MUST NOT** introduce enforceable requirements disconnected from this standard's governance framework (LEBOSS-PROT-4).
+- Conformance evaluation **MUST NOT** be limited to register rules while ignoring applicable protocol-level normative requirements (LEBOSS-PROT-3).
+- Incorporated protocol documents **MUST NOT** introduce normative requirements that are not traceable to the governance model defined in this standard (LEBOSS-PROT-4).
 - Incorporation under LEBOSS-PROT-1 makes a protocol rule normatively binding without requiring separate listing in the register (LEBOSS-PROT-5).
 
 The normative rules for protocol normativity (LEBOSS-PROT-1 through PROT-5) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.23
+**Updated Through:** proposal/0.0.24
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.23, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.24, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.23. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.24. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -73,6 +73,10 @@ Items deferred beyond v0.1.0 are tracked in [STATUS.md](../STATUS.md).
 14. [Audit Record Collection Protocol](#14-audit-record-collection-protocol)
 15. [Data Portability Protocol](#15-data-portability-protocol)
 16. [Resource Model](#16-resource-model)
+17. [Cross-System Resource Identity and Mapping](#17-cross-system-resource-identity-and-mapping)
+18. [Delegation and Authority Chains](#18-delegation-and-authority-chains)
+19. [Conformance Verification](#19-conformance-verification)
+20. [Protocol Normativity Framework](#20-protocol-normativity-framework)
 
 ---
 
@@ -789,4 +793,35 @@ The normative rules for conformance verification (LEBOSS-VER-1 through VER-6) ar
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.23 — Open for community review and pull request contribution.*
+## 20. Protocol Normativity Framework
+
+The LEBOSS standard defines normative requirements across two tiers.
+
+**Tier 1 — The Normative Rule Register:** The flat rule register (`standards/leboss-normative-rules.md`) enumerates normative requirements directly. These are the rules a conformance evaluation begins with.
+
+**Tier 2 — Incorporated Protocol Documents:** Protocol documents define detailed behavioral requirements that operationalize Tier 1 rules. These requirements are expressed in the same normative language (MUST, MUST NOT) and carry the same normative force. Protocol documents are not informative supplements to the standard — they are normative extensions of it.
+
+A system that satisfies register-level rules while violating protocol-level behavioral requirements is not conformant. A system that claims conformance by interpreting protocol documents as informative guidance does not satisfy this standard.
+
+The following protocol documents are incorporated into the normative framework of this standard:
+
+| Protocol Document | Incorporated Rules |
+|------------------|--------------------|
+| Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) | LEBOSS-AGP-1 through AGP-17 |
+| Integration Descriptor Protocol (`standards/leboss-integration-protocol.md`) | LEBOSS-IDP-1 through IDP-26 |
+| Audit Record Collection Protocol (`standards/leboss-audit-protocol.md`) | LEBOSS-ACP-1 through ACP-24 |
+| Data Portability Protocol (`standards/leboss-data-portability-protocol.md`) | LEBOSS-DPP-1 through DPP-28 |
+
+**Key behavioral requirements:**
+
+- A system claiming LEBOSS compliance **MUST** satisfy the behavioral requirements of all incorporated protocol documents (LEBOSS-PROT-1).
+- Protocol-level MUST and MUST NOT requirements **MUST NOT** be treated as non-binding guidance (LEBOSS-PROT-2).
+- Conformance evaluation **MUST NOT** be limited to register rules while ignoring applicable protocol-level behavioral requirements (LEBOSS-PROT-3).
+- Incorporated protocol documents **MUST NOT** introduce enforceable requirements disconnected from this standard's governance framework (LEBOSS-PROT-4).
+- Incorporation under LEBOSS-PROT-1 makes a protocol rule normatively binding without requiring separate listing in the register (LEBOSS-PROT-5).
+
+The normative rules for protocol normativity (LEBOSS-PROT-1 through PROT-5) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.24 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Closes the protocol normativity gap identified in the 0.0.21 boundary stress test. LEBOSS protocol documents defined ~75 normative behavioral requirements (AGP-1–17, IDP-1–26, ACP-1–24, DPP-1–28) with no formal normative standing in the rule register — allowing a system to pass register-level conformance evaluation while violating protocol behavioral requirements.

**Fix:** New rule group `PROT` (5 rules) formally incorporates the four protocol documents into the normative framework by reference. Protocol MUST/MUST NOT rules now carry the same normative weight as register rules. Non-conformance condition 20 makes protocol-only compliance a detectable conformance failure.

- Rule count: 80 → 85
- MUST: 55 → 57 | MUST NOT: 28 → 31 | MAY: 5 (unchanged)
- No new behavioral requirements introduced — alignment only

## Changes

- `standards/leboss-normative-rules.md` — Add PROT group (PROT-1 through PROT-5); update summary counts; update Gaps section to reflect normative standing formalized under PROT-1
- `standards/leboss-standard.md` — Add §20 Protocol Normativity Framework; update ToC; update version stamps 0.0.23 → 0.0.24
- `standards/conformance.md` — Add condition 20 (Protocol-only compliance); update header
- `proposals/0.0.24/proposal.md` — Proposal document

## Sequence

- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
- 0.0.23 — Closed service provider boundary (SVC-8, SVC-9)
- **0.0.24 — Aligns protocol requirements with normative rule register (PROT-1 through PROT-5)**