### PR TITLE
feat(standard): actor identity portability (0.0.25)

### DIFF
--- a/proposals/0.0.25/proposal.md
+++ b/proposals/0.0.25/proposal.md
@@ -1,0 +1,137 @@
+# Proposal 0.0.25 — Actor Identity Portability
+
+**Status:** Draft
+**Target Version:** 0.0.25
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`
+
+---
+
+## Summary
+
+This proposal closes an accountability continuity gap identified in the 0.0.21 boundary stress test: actor identity references in governance objects are not required to be portable or interpretable across systems. A governing entity who exports their audit history and migrates to a new environment may find that actor references in Audit Records — who performed each action — cannot be resolved without access to the originating system's identity infrastructure.
+
+The fix is minimal: a new rule group, `ACTOR`, establishes that actor identity in governance objects must be portable and that exports must include sufficient context to preserve accountability semantics. Six rules (ACTOR-1 through ACTOR-6) define what portability requires without prescribing identity systems, authentication mechanisms, or identifier formats. A new non-conformance condition (condition 21) makes opaque actor identity a detectable conformance failure.
+
+---
+
+## Motivation
+
+The LEBOSS governance model requires that every governed action be auditable — that the governing entity can determine what happened, to which resources, and who was accountable. This requirement is expressed across multiple rules: LEBOSS-SEC-3, LEBOSS-SVC-3, LEBOSS-SVC-4, LEBOSS-REC-1, and the full ACP protocol (LEBOSS-ACP-1 through ACP-24).
+
+Audit Records and Access Grants reference actors. What the standard has not established is that those references must remain interpretable after export and migration.
+
+**The exploitable condition:** A system stores actor identity as internal identifiers — a database-assigned user ID, a session-scoped token, an internal role code. The export faithfully includes these identifiers. A receiving system imports the audit history. The governance record shows that "user_id: 5847" revoked an Access Grant at a specific time — but no independent party can determine who user_id 5847 was. Accountability is structurally present but semantically opaque.
+
+This breaks:
+
+- The governing entity's ability to understand their own governance history after migration
+- VER rules (LEBOSS-VER-2, VER-4): compliance claims must be supportable through observable audit records — but opaque actor references prevent independent verification
+- PORT rules (LEBOSS-PORT-4): exports must be sufficient to reconstruct the governed environment independently — but an audit history with unresolvable actor references is not independently usable
+
+No existing rule requires that actor identity be portable or that exports include sufficient context to interpret actor references. The MAP rules (MAP-1 through MAP-6) address resource identity. This proposal addresses actor identity as a distinct concern.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-normative-rules.md` — Add ACTOR group and update counts
+
+**New rule group: ACTOR — Actor Identity Portability Rules** (6 rules)
+
+- **LEBOSS-ACTOR-1** (MUST): Actor identity references in governance objects must be portable — carrying sufficient context to remain interpretable in a receiving system without access to the originating system's internal state or identity infrastructure.
+- **LEBOSS-ACTOR-2** (MUST NOT): A conformant system must not export governance objects containing actor identity references that are meaningful only within the originating system's internal state and are not accompanied by sufficient context for interpretation in a receiving system.
+- **LEBOSS-ACTOR-3** (MUST): An export must include sufficient actor identity context for each actor referenced in governance objects to enable a receiving system to determine the accountable party for each governed action without access to the source system or its service providers.
+- **LEBOSS-ACTOR-4** (MUST NOT): Governance history must not become opaque as a result of actor identity resolution failure after export or migration. An export that renders actor references in Audit Records unresolvable or uninterpretable does not satisfy this standard.
+- **LEBOSS-ACTOR-5** (MUST): Actor identity portability must preserve accountability semantics — it is not sufficient that an actor identifier be structurally present in an export; the identity information must be sufficient to determine accountability for each governed action in a new environment.
+- **LEBOSS-ACTOR-6** (MUST NOT): Actor identity in governance objects must not depend on systems or infrastructure external to the governed environment that are unavailable to or inaccessible by an independent receiving system.
+
+**Summary counts updated:** 85 → 91 rules. MUST: 57 → 60. MUST NOT: 31 → 34. MAY: 5 (unchanged).
+
+**Gaps section header updated:** proposal/0.0.24 → proposal/0.0.25.
+
+**Header and footer updated:** proposal/0.0.24 → proposal/0.0.25.
+
+### 2. `standards/leboss-standard.md` — Add §21 Actor Identity Portability
+
+New section establishes the actor identity portability doctrine:
+
+- The accountability gap: governance objects reference actors using identifiers that may be system-internal and not interpretable after export
+- What portability requires: sufficient context to determine accountability without the source system
+- Accountability semantics distinction: structural presence of an identifier is not the same as interpretability
+- Cross-reference to ACTOR-1 through ACTOR-6
+
+**ToC updated:** §21 entry added.
+
+**Version stamps updated:** proposal/0.0.24 → proposal/0.0.25 throughout (header, history, §10, footer).
+
+### 3. `standards/conformance.md` — Add condition 21
+
+**Condition 21 — Opaque actor identity:** the system exports governance objects — including Audit Records, Access Grants, or Integration Descriptors — in which actor identity references are not interpretable in a receiving system, or produces an export in which actor accountability cannot be determined without access to the originating system's identity infrastructure or internal state (LEBOSS-ACTOR-2, LEBOSS-ACTOR-4).
+
+**Header updated:** proposal/0.0.24 → proposal/0.0.25.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-normative-rules.md` | Add ACTOR group (6 rules); update summary counts; update header/footer | Normative addition |
+| `standards/leboss-standard.md` | Add §21; update ToC; update version stamps | Normative addition |
+| `standards/conformance.md` | Add condition 21; update header | Normative addition |
+
+**Rule count:** 85 → 91
+**MUST count:** 57 → 60 (ACTOR-1, ACTOR-3, ACTOR-5 add 3 MUSTs)
+**MUST NOT count:** 31 → 34 (ACTOR-2, ACTOR-4, ACTOR-6 add 3 MUST NOTs)
+**MAY count:** 5 (unchanged)
+
+---
+
+## What This Proposal Does Not Define
+
+This proposal governs the portability and interpretability of actor identity in governance objects. It does not define:
+
+- Identity systems, authentication mechanisms, or authorization protocols
+- Identifier formats (UUIDs, email addresses, or any other structure)
+- Specific identity providers or directory services
+- Implementation-specific identity models or federation patterns
+- How identity context is stored, structured, or encoded in exports
+
+The standard governs **what must be true about actor identity portability** — that references remain interpretable and accountability semantics are preserved. How that requirement is satisfied is implementation-defined.
+
+---
+
+## Relationship to Existing Rules
+
+| Existing Rule | Relationship |
+|---------------|-------------|
+| LEBOSS-MAP-1 through MAP-6 | MAP rules govern *resource* identity portability. ACTOR rules govern *actor* identity portability. These are complementary, non-overlapping concerns. |
+| LEBOSS-PORT-4 | Exports must be sufficient to reconstruct the governed environment independently. ACTOR-3 and ACTOR-5 make this requirement concrete for the actor identity dimension. |
+| LEBOSS-VER-2, VER-4 | Compliance claims must be supportable through observable audit records. Opaque actor references prevent independent verification — ACTOR rules close the gap. |
+| LEBOSS-REC-1, REC-3 | Audit Records are the authoritative record of governed actions. ACTOR rules ensure that record remains authoritative after migration, not just within the originating system. |
+| LEBOSS-ACP (protocol) | ACP defines capture, retention, and integrity requirements for Audit Records. ACTOR rules extend those requirements to require that records remain interpretable across system boundaries. |
+
+---
+
+## Backward Compatibility
+
+Systems where exported governance objects include sufficient actor identity context are unaffected. Systems that export actor identifiers as opaque system-internal references may now be required to:
+
+- Include actor identity context alongside system-internal identifiers in governance object exports
+- Ensure that actor references in Audit Records are interpretable to a receiving system
+
+This is intentional. The prior state allowed a system to produce exports that were technically complete while rendering accountability history uninterpretable outside the originating environment.
+
+---
+
+## Sequence Context
+
+- 0.0.21 — Stress test; identified protocol normativity gap and actor identity portability gap
+- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
+- 0.0.23 — Closed service provider boundary (SVC-8, SVC-9)
+- 0.0.24 — Aligned protocol requirements with normative rule register (PROT-1 through PROT-5)
+- 0.0.25 — Establishes actor identity portability requirements (ACTOR-1 through ACTOR-6)
+
+---
+
+*Proposal 0.0.25 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.24
+**Updated Through:** proposal/0.0.25
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -228,6 +228,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 19. **Ungoverned infrastructure access** — any entity with the ability to access or control systems containing primary operational data is not treated as a service provider, is not disclosed to the governing entity, or is not subject to the service provider obligations and access grant requirements of this standard (LEBOSS-SVC-8, LEBOSS-SVC-9).
 
 20. **Protocol-only compliance** — the system satisfies register-level normative rules while failing to satisfy behavioral requirements defined in incorporated LEBOSS protocol documents (LEBOSS-AGP-1 through AGP-17, LEBOSS-IDP-1 through IDP-26, LEBOSS-ACP-1 through ACP-24, LEBOSS-DPP-1 through DPP-28), or treats protocol-level MUST and MUST NOT requirements as non-binding guidance rather than normative obligations (LEBOSS-PROT-1, LEBOSS-PROT-2, LEBOSS-PROT-3).
+
+21. **Opaque actor identity** — the system exports governance objects — including Audit Records, Access Grants, or Integration Descriptors — in which actor identity references are not interpretable in a receiving system, or produces an export in which actor accountability cannot be determined without access to the originating system's identity infrastructure or internal state (LEBOSS-ACTOR-2, LEBOSS-ACTOR-4).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.24
+**Updated Through:** proposal/0.0.25
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -32,6 +32,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `DEL` — Delegation and Authority Chain Rules
 - `VER` — Conformance Verification Rules
 - `PROT` — Protocol Normativity Rules
+- `ACTOR` — Actor Identity Portability Rules
 
 ---
 
@@ -433,7 +434,8 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Delegation and Authority Chains (DEL)   | 6 | 3  | 3  | — | — |
 | Conformance Verification (VER)          | 6 | 4  | 4  | — | — |
 | Protocol Normativity (PROT)             | 5 | 2  | 3  | — | — |
-| **Total**                           | **85** | **57** | **31** | **5** | **—** |
+| Actor Identity Portability (ACTOR)      | 6 | 3  | 3  | — | — |
+| **Total**                           | **91** | **60** | **34** | **5** | **—** |
 
 ---
 
@@ -461,9 +463,37 @@ Where an incorporated LEBOSS protocol defines required behavior through MUST or 
 
 ---
 
+## Actor Identity Portability Rules
+
+**LEBOSS-ACTOR-1**
+Actor identity references in governance objects — including Audit Records, Access Grants, and Integration Descriptors — MUST be portable. An actor reference is portable if it can be interpreted in a receiving system without access to the originating system's internal state or identity infrastructure.
+*Source: §21*
+
+**LEBOSS-ACTOR-2**
+A conformant system MUST NOT export governance objects containing actor identity references that are meaningful only within the originating system's internal state and that are not accompanied by sufficient context for interpretation in a receiving system.
+*Source: §21*
+
+**LEBOSS-ACTOR-3**
+An export MUST include sufficient actor identity context for each actor referenced in governance objects to enable a receiving system to determine the accountable party for each governed action without access to the source system or its service providers.
+*Source: §21*
+
+**LEBOSS-ACTOR-4**
+Governance history MUST NOT become opaque as a result of actor identity resolution failure after export or migration. An export that renders actor references in Audit Records unresolvable or uninterpretable does not satisfy this standard.
+*Source: §21*
+
+**LEBOSS-ACTOR-5**
+Actor identity portability MUST preserve accountability semantics. It is not sufficient that an actor identifier be structurally present in an export — the identity information must be sufficient to determine accountability for each governed action in a new environment.
+*Source: §21*
+
+**LEBOSS-ACTOR-6**
+Actor identity in governance objects MUST NOT depend on systems or infrastructure external to the governed environment that are unavailable to or inaccessible by an independent receiving system.
+*Source: §21*
+
+---
+
 ## Gaps Identified
 
-The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.24.
+The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.25.
 
 **GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4; normative standing formalized in 0.0.24*
 The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
@@ -482,4 +512,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.24. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.25. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.24
+**Updated Through:** proposal/0.0.25
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.24, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.25, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.24. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.25. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -77,6 +77,7 @@ Items deferred beyond v0.1.0 are tracked in [STATUS.md](../STATUS.md).
 18. [Delegation and Authority Chains](#18-delegation-and-authority-chains)
 19. [Conformance Verification](#19-conformance-verification)
 20. [Protocol Normativity Framework](#20-protocol-normativity-framework)
+21. [Actor Identity Portability](#21-actor-identity-portability)
 
 ---
 
@@ -549,7 +550,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.23.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.25.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -824,4 +825,29 @@ The normative rules for protocol normativity (LEBOSS-PROT-1 through PROT-5) are 
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.24 — Open for community review and pull request contribution.*
+## 21. Actor Identity Portability
+
+The LEBOSS governance model requires that every governed action be auditable — that a governing entity can determine what happened, to which resources, and who was accountable. Audit Records name actors. Access Grants name the subject being authorized. This accountability chain is central to data sovereignty.
+
+That accountability becomes meaningless if actor identity cannot be interpreted outside the system that recorded it. A governing entity who exports their audit history and migrates to a new environment must be able to read their governance record — including who was accountable for each action — without requiring access to the originating system's identity infrastructure, directory services, or internal state.
+
+**The gap this section addresses:** Governance objects routinely store actor references using identifiers that are internal to a specific system — database-assigned user IDs, session-scoped tokens, internal role codes, or similar constructs. When exported, these identifiers are structurally present but semantically opaque. An audit record may show that an action occurred and that a specific identifier performed it, while providing no means for an independent party to determine who that identifier represents in accountability terms. The governance record is intact but uninterpretable.
+
+This is not a hypothetical edge case. It is the default behavior of most identity and access management architectures. Without an explicit requirement for portability, every compliant system may — and most will — produce audit histories that become governance dead-ends after migration.
+
+This section does not define identity systems, authentication mechanisms, or identifier formats. It defines what must be true about actor identity in governance objects: that references carry sufficient context to preserve accountability semantics across system boundaries.
+
+**Key behavioral requirements:**
+
+- Actor identity references in governance objects **MUST** be portable — carrying sufficient context to remain interpretable in a receiving system without access to the originating system's internal state or identity infrastructure (LEBOSS-ACTOR-1).
+- A conformant system **MUST NOT** export governance objects in which actor identity references are meaningful only within the originating system's internal state (LEBOSS-ACTOR-2).
+- An export **MUST** include sufficient actor identity context to enable a receiving system to determine the accountable party for each governed action without access to the source system (LEBOSS-ACTOR-3).
+- Governance history **MUST NOT** become opaque as a result of actor identity resolution failure after export or migration (LEBOSS-ACTOR-4).
+- Actor identity portability **MUST** preserve accountability semantics — structural presence of an identifier is not sufficient; the identity information must enable accountability determination in a new environment (LEBOSS-ACTOR-5).
+- Actor identity in governance objects **MUST NOT** depend on external systems or infrastructure unavailable to an independent receiving system (LEBOSS-ACTOR-6).
+
+The normative rules for actor identity portability (LEBOSS-ACTOR-1 through ACTOR-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.25 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Closes the actor identity portability gap identified in the 0.0.21 boundary stress test.

Governance objects (Audit Records, Access Grants, Integration Descriptors) reference actors using identifiers that may be system-internal and uninterpretable after export. A governing entity who migrates their governed environment to a new system may find that their audit history is structurally intact but semantically opaque — they can see that an action occurred but not who was accountable for it.

**Changes:**

- `standards/leboss-normative-rules.md` — Add ACTOR rule group (ACTOR-1 through ACTOR-6); update summary counts (85 → 91 rules); update header/footer
- `standards/leboss-standard.md` — Add §21 Actor Identity Portability; update ToC; update version stamps
- `standards/conformance.md` — Add condition 21 (Opaque actor identity); update header
- `proposals/0.0.25/proposal.md` — Proposal document

**Rule count:** 85 → 91 | **MUST:** 57 → 60 | **MUST NOT:** 31 → 34 | **MAY:** 5 (unchanged)

**What this does not define:** identity systems, authentication mechanisms, identifier formats, identity providers, or implementation-specific identity models.