### PR TITLE
feat(standard): define audit resolution and verifiability requirements (0.0.27)

### DIFF
--- a/proposals/0.0.27/proposal.md
+++ b/proposals/0.0.27/proposal.md
@@ -1,0 +1,138 @@
+# Proposal 0.0.27 — Audit Resolution Requirements
+
+**Status:** Draft
+**Target Version:** 0.0.27
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`
+
+---
+
+## Summary
+
+This proposal closes a structural gap identified in the 0.0.21 boundary stress test (Scenario 2: \"The Coarse-Grained Audit Log\"): a system can satisfy all existing audit requirements — REC rules, ACP behavioral rules, immutability guarantees — while producing audit records so coarse that they cannot support meaningful compliance verification.
+
+The existing audit requirements establish that records MUST exist, MUST be immutable, MUST be treated as authoritative, and MUST be available to the governing entity. None of these requirements address the *resolution* of those records: whether they contain enough detail to determine what actually happened, whether the action was within authorized scope, or whether accountability can be assigned independently.
+
+The fix is a new rule group, `AUD`, with six rules (AUD-1 through AUD-6) that define the minimum informational content required for an audit record to satisfy accountability and verifiability obligations under this standard. A new non-conformance condition (condition 23) makes insufficient audit resolution a disqualifying conformance failure.
+
+---
+
+## Motivation
+
+The LEBOSS standard's audit model rests on a chain of obligations:
+
+1. Every governed action MUST be recorded (SEC-3, SVC-3, REC-1)
+2. Records MUST be immutable (via Audit Record Collection Protocol, ACP-12 through ACP-14)
+3. Records MUST be authoritative (REC-1 through REC-3)
+4. Records MUST be available to the governing entity (SVC-4)
+5. Records MUST support independent verification of compliance (VER-2, VER-4)
+
+The gap appears at step 5. VER-2 requires that compliance claims be supportable through observable system behavior and audit records. VER-4 requires sufficient visibility for an independent party to verify conformance. But neither rule, nor any rule in the REC group, defines what level of detail in an audit record is sufficient to support that verification.
+
+**The exploitable condition:** A system can produce audit records that document only that a data access event occurred — with no indication of which specific resources were accessed, no record of what operation was performed, no outcome recorded, and no basis for evaluating whether the access was within the authorized grant scope. Every REC rule and every ACP behavioral rule is satisfied. The audit log exists, is immutable, and is available. It is also useless for governance.
+
+This is not a hypothetical. Event-driven logging architectures commonly record event types without resource payloads. Batch processing systems log job completions rather than individual operations. High-volume systems aggregate audit events for storage efficiency. In all these cases, a governing entity who requests their audit history for a compliance review receives a record that tells them events occurred but cannot tell them what those events were, whether they were authorized, or who was accountable.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-normative-rules.md` — Add AUD group and update header, counts, and Gaps
+
+**New rule group: AUD — Audit Resolution Requirements** (6 rules)
+
+- **LEBOSS-AUD-1** (MUST): Audit records must contain sufficient detail to determine what specific resources were accessed or affected, what operation was performed, and the outcome of that operation.
+- **LEBOSS-AUD-2** (MUST): Audit records must be sufficiently granular to allow determination of whether the access was within the scope authorized by the applicable Access Grant.
+- **LEBOSS-AUD-3** (MUST NOT): A conformant system must not produce audit records that aggregate, summarize, or omit resource-level and operation-level detail in a manner that prevents verification of whether individual governed actions were within authorized scope.
+- **LEBOSS-AUD-4** (MUST): Audit records must support reconstruction of governed actions from the audit record alone, without reliance on system state, service provider cooperation, or information not present in the record itself.
+- **LEBOSS-AUD-5** (MUST NOT): A conformant system must not produce audit records interpretable only with knowledge of internal system state, internal nomenclature, or conventions unavailable to an independent evaluator.
+- **LEBOSS-AUD-6** (MUST NOT): A conformant system must not satisfy audit recording requirements by producing records that document the occurrence of governed events while omitting the detail required to evaluate whether those events were authorized.
+
+**Summary counts updated:** 97 → 103 rules. MUST: 63 → 66. MUST NOT: 37 → 40. MAY: 5 (unchanged).
+
+**Gaps section updated:** through proposal 0.0.27.
+
+**Header updated:** proposal/0.0.26 → proposal/0.0.27.
+
+### 2. `standards/leboss-standard.md` — Add §23 Audit Resolution Requirements
+
+New section establishes the audit resolution doctrine:
+
+- The distinction between audit existence and audit sufficiency
+- The gap between satisfying recording requirements and enabling meaningful verification
+- What this section does NOT define (no schemas, no formats, no storage systems)
+- Key behavioral requirements citing AUD-1 through AUD-6
+
+**ToC updated:** `23. [Audit Resolution Requirements](#23-audit-resolution-requirements)` added.
+
+**Version stamps updated:** proposal/0.0.26 → proposal/0.0.27 throughout.
+
+### 3. `standards/conformance.md` — Add condition 23
+
+**Condition 23 — Insufficient audit resolution:** the system produces audit records that satisfy recording requirements but omit the resource-level or operation-level detail required to verify whether governed actions were within authorized scope, or produces an audit corpus that an independent party cannot use to evaluate governed action legality without access to system state, internal nomenclature, or service provider cooperation (LEBOSS-AUD-3, LEBOSS-AUD-5, LEBOSS-AUD-6).
+
+**Header updated:** proposal/0.0.26 → proposal/0.0.27.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-normative-rules.md` | Add AUD group (6 rules); update summary counts; update Gaps section | Normative addition — defines audit resolution floor |
+| `standards/leboss-standard.md` | Add §23; update ToC; update version stamps | Normative addition |
+| `standards/conformance.md` | Add condition 23; update header | Normative addition |
+
+**Rule count:** 97 → 103
+**MUST count:** 63 → 66 (AUD-1, AUD-2, AUD-4 add 3 MUSTs)
+**MUST NOT count:** 37 → 40 (AUD-3, AUD-5, AUD-6 add 3 MUST NOTs)
+**MAY count:** 5 (unchanged)
+
+---
+
+## Relationship to Existing Rules
+
+**AUD vs REC:** The REC group establishes that audit records are the authoritative system of record and must be immutable (REC-1 through REC-4). AUD does not modify the system-of-record obligations — it defines the resolution floor that makes those records useful for verification. REC says audit records are authoritative; AUD says they must contain enough to be worth consulting.
+
+**AUD and VER:** VER-2 requires that compliance claims be supportable through observable system behavior and audit records. VER-4 requires sufficient visibility for independent conformance verification. AUD-4 and AUD-6 directly operationalize these requirements within the audit domain: audit records must support independent verification of rule compliance, not merely document that events occurred.
+
+**AUD and ACC:** AUD-2 requires that audit granularity enables evaluation against the applicable Access Grant. This connects audit resolution to grant scope enforcement: an audit corpus that cannot be compared to grant scope cannot support ACC-4 compliance evaluation (a service provider MUST operate only within the scope of explicitly granted access).
+
+**AUD and REC-2:** REC-2 prohibits representing resource state irreconcilably with audit history. AUD extends this: if audit records lack resource-level detail, reconciliation is impossible regardless of intent. AUD does not replace REC-2 — it defines a prerequisite for it.
+
+---
+
+## What This Proposal Does Not Define
+
+This proposal does not define:
+
+- Audit record schemas or field structures
+- Logging formats (JSON, structured logging, syslog, etc.)
+- Storage systems, retention mechanisms, or log aggregation architecture
+- Specific field names, attribute types, or data representations
+- Implementation strategies for achieving audit granularity
+
+The standard governs what level of detail must be present in an audit record. How that detail is captured, structured, and stored is an implementation concern deferred to the implementing system and, where applicable, to the Audit Record Collection Protocol (LEBOSS-ACP-1 through ACP-24).
+
+---
+
+## Backward Compatibility
+
+Systems that already produce sufficiently detailed audit records are unaffected. Systems that produce coarse-grained audit logs — documenting event occurrence without resource-level or operation-level specificity — may now be required to increase audit granularity to satisfy AUD-1 through AUD-6.
+
+This is intentional. A system that records only that a data access occurred, without recording what was accessed, what was done to it, or whether the operation completed successfully, provides no meaningful basis for governance accountability — regardless of how immutably that non-information is stored.
+
+---
+
+## Sequence Context
+
+- 0.0.21 — Stress test; Scenario 2 identified the coarse-grained audit gap
+- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
+- 0.0.23 — Closed service provider boundary (SVC-8, SVC-9)
+- 0.0.24 — Aligned protocol requirements with normative rule register (PROT-1 through PROT-5)
+- 0.0.25 — Established actor identity portability requirements (ACTOR-1 through ACTOR-6)
+- 0.0.26 — Established governing entity authenticity requirements (GEA-1 through GEA-6)
+- 0.0.27 — Defines audit resolution floor (AUD-1 through AUD-6)
+
+---
+
+*Proposal 0.0.27 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.26
+**Updated Through:** proposal/0.0.27
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -232,6 +232,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 21. **Opaque actor identity** — the system exports governance objects — including Audit Records, Access Grants, or Integration Descriptors — in which actor identity references are not interpretable in a receiving system, or produces an export in which actor accountability cannot be determined without access to the originating system's identity infrastructure or internal state (LEBOSS-ACTOR-2, LEBOSS-ACTOR-4).
 
 22. **Platform-dependent ownership** — the system defines or controls governing entity authority in a manner that makes it dependent on service provider accounts, platform-controlled identifiers, or system-generated constructs that do not represent the real-world entity they purport to govern; or permits a service provider to unilaterally modify, reassign, or revoke governing entity status without the authorization of the party the governing entity represents (LEBOSS-GEA-2, LEBOSS-GEA-3, LEBOSS-GEA-5).
+
+23. **Insufficient audit resolution** — the system produces audit records that satisfy recording requirements but omit the resource-level or operation-level detail required to verify whether governed actions were within authorized scope, or produces an audit corpus that an independent party cannot use to evaluate governed action legality without access to system state, internal nomenclature, or service provider cooperation (LEBOSS-AUD-3, LEBOSS-AUD-5, LEBOSS-AUD-6).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.26
+**Updated Through:** proposal/0.0.27
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -34,6 +34,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `PROT` — Protocol Normativity Rules
 - `ACTOR` — Actor Identity Portability Rules
 - `GEA` — Governing Entity Authenticity Rules
+- `AUD` — Audit Resolution Requirements Rules
 
 ---
 
@@ -437,7 +438,8 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Protocol Normativity (PROT)             | 5 | 2  | 3  | — | — |
 | Actor Identity Portability (ACTOR)      | 6 | 3  | 3  | — | — |
 | Governing Entity Authenticity (GEA)     | 6 | 3  | 3  | — | — |
-| **Total**                           | **97** | **63** | **37** | **5** | **—** |
+| Audit Resolution Requirements (AUD)     | 6 | 3  | 3  | — | — |
+| **Total**                           | **103** | **66** | **40** | **5** | **—** |
 
 ---
 
@@ -521,9 +523,37 @@ A conformant system MUST ensure that governing entity authority is independently
 
 ---
 
+## Audit Resolution Requirements Rules
+
+**LEBOSS-AUD-1**
+Audit records MUST contain sufficient detail to determine what specific resources were accessed or affected, what operation was performed, and the outcome of that operation. A record that documents only the occurrence of an event without resource-level and operation-level specificity does not satisfy this requirement.
+*Source: §23*
+
+**LEBOSS-AUD-2**
+Audit records MUST be sufficiently granular to allow determination of whether the access described was within the scope defined by the applicable Access Grant. An audit record that cannot be evaluated against the grant that authorized the action does not satisfy this standard.
+*Source: §23*
+
+**LEBOSS-AUD-3**
+A conformant system MUST NOT produce audit records that aggregate, summarize, or omit resource-level and operation-level detail in a manner that prevents verification of whether individual governed actions were within authorized scope.
+*Source: §23*
+
+**LEBOSS-AUD-4**
+Audit records MUST support reconstruction of governed actions from the audit record alone, without reliance on system state, service provider cooperation, or information not present in the audit record itself.
+*Source: §23*
+
+**LEBOSS-AUD-5**
+A conformant system MUST NOT produce audit records that are interpretable only with knowledge of internal system state, internal nomenclature, or conventions unavailable to an independent evaluator. Audit records must carry sufficient context to be self-interpreting with respect to the governed action they document.
+*Source: §23*
+
+**LEBOSS-AUD-6**
+A conformant system MUST NOT satisfy audit recording requirements by producing records that document the occurrence of governed events while omitting the detail required to evaluate whether those events were authorized. Recording that an event occurred is not equivalent to recording what that event was.
+*Source: §23*
+
+---
+
 ## Gaps Identified
 
-The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.26.
+The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.27.
 
 **GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4; normative standing formalized in 0.0.24*
 The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
@@ -542,4 +572,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.26. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.27. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.26
+**Updated Through:** proposal/0.0.27
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.26, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.27, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.26. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.27. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -79,6 +79,7 @@ Items deferred beyond v0.1.0 are tracked in [STATUS.md](../STATUS.md).
 20. [Protocol Normativity Framework](#20-protocol-normativity-framework)
 21. [Actor Identity Portability](#21-actor-identity-portability)
 22. [Governing Entity Authenticity](#22-governing-entity-authenticity)
+23. [Audit Resolution Requirements](#23-audit-resolution-requirements)
 
 ---
 
@@ -551,7 +552,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.26.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.27.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -876,4 +877,29 @@ The normative rules for governing entity authenticity (LEBOSS-GEA-1 through GEA-
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.26 — Open for community review and pull request contribution.*
+## 23. Audit Resolution Requirements
+
+The LEBOSS audit model requires that governed actions be recorded, that those records be immutable and authoritative, and that the governing entity can access them at any time. These requirements ensure that an audit corpus exists. They do not ensure that it is useful.
+
+An audit record can satisfy every recording requirement while providing no meaningful basis for governance accountability. A log entry that documents only that a data access event occurred — with no indication of which resources were accessed, no record of the operation performed, no outcome captured — is structurally compliant and functionally useless. The governing entity possesses an immutable record of nothing actionable.
+
+**The gap this section addresses:** The existing audit requirements establish existence, immutability, and availability. They do not establish resolution — the level of informational detail required for an audit record to support verification of whether a governed action was authorized, whether it was within scope, and who was accountable for it. Without a resolution floor, satisfying audit recording requirements is compatible with producing audit records that tell a governing entity, or an independent evaluator, essentially nothing.
+
+This gap undermines the standard's accountability model at its foundation. An audit corpus that documents event occurrence without action-level specificity cannot support evaluation of ACC-4 compliance (service providers must operate only within grant scope). It cannot support VER-2 (compliance claims must be supportable through observable system behavior and audit records). It cannot support VER-4 (independent parties must be able to verify conformance). Audit existence without audit resolution makes the governance record a procedural artifact rather than an accountability instrument.
+
+This section does not define schemas, field structures, logging formats, storage systems, or specific data representations. It defines the informational floor: what must be true about the content of an audit record for it to satisfy accountability and verifiability obligations under this standard.
+
+**Key behavioral requirements:**
+
+- Audit records **MUST** contain sufficient detail to determine what specific resources were accessed or affected, what operation was performed, and the outcome of that operation (LEBOSS-AUD-1).
+- Audit records **MUST** be sufficiently granular to allow determination of whether the access was within the scope defined by the applicable Access Grant (LEBOSS-AUD-2).
+- A conformant system **MUST NOT** produce audit records that aggregate, summarize, or omit resource-level and operation-level detail in a manner that prevents verification of whether individual governed actions were within authorized scope (LEBOSS-AUD-3).
+- Audit records **MUST** support reconstruction of governed actions from the record alone, without reliance on system state, service provider cooperation, or information not present in the record itself (LEBOSS-AUD-4).
+- A conformant system **MUST NOT** produce audit records that are interpretable only with knowledge of internal system state, internal nomenclature, or conventions unavailable to an independent evaluator (LEBOSS-AUD-5).
+- A conformant system **MUST NOT** satisfy audit recording requirements by producing records that document the occurrence of governed events while omitting the detail required to evaluate whether those events were authorized (LEBOSS-AUD-6).
+
+The normative rules for audit resolution requirements (LEBOSS-AUD-1 through AUD-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.27 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Closes the coarse-grained audit gap identified in the 0.0.21 stress test (Scenario 2).

The existing REC rules and ACP protocol require that audit records exist, are immutable, and are available. No requirement establishes the informational floor — what level of detail a record must contain to support meaningful accountability verification. A system can satisfy all recording requirements while producing audit logs that document event occurrence without resource-level specificity, operation detail, or outcome.

This proposal introduces **LEBOSS-AUD-1 through AUD-6**, a new `AUD` rule group defining audit resolution requirements: what a record must contain, what it must enable, and what it must not omit.

## Changes

- **`standards/leboss-normative-rules.md`** — Add `AUD` group (6 rules); update Rule Numbering, Summary Counts (97 → 103), Gaps section header, and footer
- **`standards/leboss-standard.md`** — Add §23 Audit Resolution Requirements; update ToC, version stamps throughout
- **`standards/conformance.md`** — Add condition 23 (Insufficient audit resolution); update header
- **`proposals/0.0.27/proposal.md`** — New proposal document

## Rule Count

| | Before | After |
|---|---|---|
| Total | 97 | 103 |
| MUST | 63 | 66 |
| MUST NOT | 37 | 40 |
| MAY | 5 | 5 |

## New Rules

- **AUD-1** (MUST): Records must contain detail sufficient to determine specific resources affected, operation performed, and outcome
- **AUD-2** (MUST): Records must be granular enough to evaluate against the applicable Access Grant scope
- **AUD-3** (MUST NOT): Must not aggregate or omit detail in ways that prevent scope verification
- **AUD-4** (MUST): Records must support reconstruction of governed actions without system state or service provider cooperation
- **AUD-5** (MUST NOT): Must not produce records interpretable only with internal system knowledge
- **AUD-6** (MUST NOT): Must not satisfy recording requirements while omitting authorization-evaluation detail

## Non-Conformance Condition Added

Condition 23 — **Insufficient audit resolution**: audit records that satisfy recording requirements while omitting detail required to verify scope compliance or evaluate governed action legality (LEBOSS-AUD-3, LEBOSS-AUD-5, LEBOSS-AUD-6).

## Scope Boundaries

No schemas, field structures, logging formats, storage systems, or implementation strategies defined. Only the informational floor is normative.