### PR TITLE
feat(standard): define delegation chain lifetime integrity requirements (0.0.28)

### DIFF
--- a/proposals/0.0.28/proposal.md
+++ b/proposals/0.0.28/proposal.md
@@ -1,0 +1,147 @@
+# Proposal 0.0.28 — Delegation Chain Lifetime Integrity
+
+**Status:** Draft
+**Target Version:** 0.0.28
+**Scope:** `standards/leboss-standard.md`, `standards/leboss-normative-rules.md`, `standards/conformance.md`
+
+---
+
+## Summary
+
+This proposal closes a temporal integrity gap identified in the 0.0.21 boundary stress test (Scenario 4: \"The Audit-Retention Cliff\"): a delegation chain can satisfy all structural DEL rules — correct scope, traceable to root, no ambiguity — while the audit evidence that makes that chain independently verifiable expires under normal retention policy.
+
+The DEL group (DEL-1 through DEL-6) establishes structural constraints on delegation: a delegate cannot exceed the authority that delegated to them, every delegation must reference its origin, chains must trace to the root governing entity grant, and revocation must propagate. These rules are enforced at the time of issuance and evaluation. None of them require that the evidence supporting the chain remain available for as long as the chain is active.
+
+The fix is a new rule group, `DCL`, with six rules (DCL-1 through DCL-6) that bind delegation authority to the continued existence of its verifiable evidence. A delegation chain that has become unverifiable — for any reason — cannot continue to authorize access under this standard. A new non-conformance condition (condition 24) makes unverifiable delegation chain lifetime a disqualifying conformance failure.
+
+---
+
+## Motivation
+
+The LEBOSS delegation model requires that every delegated grant trace back to a root governing entity grant (DEL-3). This traceability requirement is structural: it governs the form of the chain at the time it is evaluated. It does not govern the persistence of the evidence that supports that evaluation.
+
+Consider the following scenario:
+
+1. The governing entity issues a root grant (Grant A) to Service Provider B.
+2. Service Provider B delegates a subset of that authority to Integration C (Grant B, referencing Grant A).
+3. Audit records for Grant A's issuance — the root governing entity grant — are created at the time of issuance.
+4. Six months later, audit records for Grant A expire under the system's retention policy.
+5. Integration C continues to operate under Grant B.
+6. An independent evaluator attempts to verify the delegation chain: Grant B → Grant A → governing entity.
+7. The root audit records are gone. The chain traces structurally in the system's internal state, but cannot be independently validated.
+
+Under the current standard, step 6 reveals no conformance failure. DEL-3 is satisfied because the system can assert the chain. But assertion by the system is not independent validation — and the audit evidence required to support independent validation no longer exists.
+
+**The exploitable condition:** A service provider can maintain active delegation authority while the evidence that would allow an independent party — including the governing entity — to verify the legitimacy of that authority has expired. The governing entity cannot independently confirm that their authority actually granted what is being exercised on their behalf.
+
+This gap is particularly significant because it allows authority chains to persist beyond the point at which the governing entity could meaningfully audit them. The purpose of the traceability requirement (DEL-3) is to ensure that authority is always traceable to the governing entity's actual authorization. That purpose is defeated if the records supporting that traceability do not persist as long as the authority they support.
+
+---
+
+## Specification Changes
+
+### 1. `standards/leboss-normative-rules.md` — Add DCL group and update header, counts, and Gaps
+
+**New rule group: DCL — Delegation Chain Lifetime Rules** (6 rules)
+
+- **LEBOSS-DCL-1** (MUST): A delegation chain must remain independently verifiable for its entire active lifetime — meaning the chain can be traced to a valid root governing entity grant through evidence that does not rely on assertions made by the implementing system or its service providers.
+- **LEBOSS-DCL-2** (MUST NOT): A conformant system must not maintain active delegation grants whose authority chain cannot be independently validated. A delegation chain that has become unverifiable — whether through loss of supporting audit evidence or any other cause — must be treated as having no valid authority.
+- **LEBOSS-DCL-3** (MUST): The audit evidence supporting each step in a delegation chain must persist for at least as long as the delegation remains active. A delegation chain that outlives the verifiable record of its origin does not satisfy this standard.
+- **LEBOSS-DCL-4** (MUST NOT): A conformant system must not allow a delegation chain to remain active after the supporting audit records establishing the root governing entity grant have become unavailable or irrecoverable.
+- **LEBOSS-DCL-5** (MUST): Loss of verifiability in any link of a delegation chain must propagate as a validity failure to all grants in that chain. A delegation chain is only as verifiable as its least-verified link.
+- **LEBOSS-DCL-6** (MUST NOT): A conformant system must not substitute its own assertions, internal state, or configuration as evidence of delegation authority when independent audit evidence is unavailable. System trust is not a substitute for independently verifiable evidence.
+
+**Summary counts updated:** 103 → 109 rules. MUST: 66 → 69. MUST NOT: 40 → 43. MAY: 5 (unchanged).
+
+**Gaps section updated:** through proposal 0.0.28.
+
+**Header updated:** proposal/0.0.27 → proposal/0.0.28.
+
+### 2. `standards/leboss-standard.md` — Add §24 Delegation Chain Lifetime Integrity
+
+New section establishes the delegation lifetime doctrine:
+
+- The distinction between structural verifiability (DEL) and temporal verifiability (DCL)
+- The specific failure mode: audit evidence expiring while delegation remains active
+- What this section does NOT define (no retention durations, no storage mechanisms)
+- Key behavioral requirements citing DCL-1 through DCL-6
+
+**ToC updated:** `24. [Delegation Chain Lifetime Integrity](#24-delegation-chain-lifetime-integrity)` added.
+
+**Version stamps updated:** proposal/0.0.27 → proposal/0.0.28 throughout.
+
+### 3. `standards/conformance.md` — Add condition 24
+
+**Condition 24 — Unverifiable delegation chain lifetime:** the system maintains active delegation grants whose authority chain cannot be independently validated due to loss or expiration of supporting audit evidence, or treats system assertions as sufficient substitute for independently verifiable delegation evidence when that evidence is unavailable (LEBOSS-DCL-2, LEBOSS-DCL-4, LEBOSS-DCL-6).
+
+**Header updated:** proposal/0.0.27 → proposal/0.0.28.
+
+---
+
+## Impact Assessment
+
+| Document | Change | Nature |
+|----------|--------|--------|
+| `standards/leboss-normative-rules.md` | Add DCL group (6 rules); update summary counts; update Gaps section | Normative addition — binds delegation authority to verifiable evidence lifetime |
+| `standards/leboss-standard.md` | Add §24; update ToC; update version stamps | Normative addition |
+| `standards/conformance.md` | Add condition 24; update header | Normative addition |
+
+**Rule count:** 103 → 109
+**MUST count:** 66 → 69 (DCL-1, DCL-3, DCL-5 add 3 MUSTs)
+**MUST NOT count:** 40 → 43 (DCL-2, DCL-4, DCL-6 add 3 MUST NOTs)
+**MAY count:** 5 (unchanged)
+
+---
+
+## Relationship to Existing Rules
+
+**DCL vs DEL:** The DEL group establishes structural constraints on delegation — scope limits, origin references, traceability, revocation propagation. DEL rules operate at the time of issuance and evaluation; they govern the form of the chain. DCL extends this into the temporal dimension: the chain must remain verifiable for as long as it remains active. DEL asks "is this chain structurally valid?" DCL asks "can this chain be independently verified right now, and will it continue to be?"
+
+**DCL and REC:** REC-1 establishes that the set of audit records for a governed environment constitutes the authoritative record of governed actions. REC-3 requires that audit records be treated as foundational. DCL-3 and DCL-4 operationalize these principles within the delegation domain: the audit records that establish delegation authority are not merely records of what happened — they are the foundation of current and ongoing authority. Their unavailability is not a historical loss; it is a present authority failure.
+
+**DCL and AUD:** AUD defines what audit records must contain (resolution requirements). DCL defines how long audit evidence supporting delegation must remain available. These rules are complementary: AUD ensures the records are sufficient; DCL ensures they persist long enough to serve their purpose.
+
+**DCL and VER:** VER-4 requires that a system provide sufficient visibility for an independent party to verify conformance. DCL-1 and DCL-6 directly operationalize this within the delegation domain: independent verifiability of delegation authority is not optional, and system assertions cannot substitute for it.
+
+**DCL and DEL-3:** DEL-3 requires that delegation chains be fully traceable to a valid root governing entity grant. DCL-1 extends this by requiring that the traceability be achievable through independent evidence, not just through the system's internal state. DEL-3 establishes what must be true structurally; DCL-1 establishes that this truth must be demonstrable without relying on the system that made the claim.
+
+---
+
+## What This Proposal Does Not Define
+
+This proposal does not define:
+
+- Retention durations or minimum retention periods for any audit record category
+- Storage mechanisms, archival systems, or backup strategies
+- How a system must detect or respond to evidence degradation
+- Implementation strategies for maintaining delegation evidence
+- Any specific data persistence technology or architecture
+
+The standard governs the relationship between delegation authority and its evidentiary basis. How a system ensures that audit evidence persists for the required period is an implementation concern.
+
+---
+
+## Backward Compatibility
+
+Systems where audit evidence already persists for the lifetime of delegation chains are unaffected. Systems where audit retention windows are shorter than delegation lifetimes may now be required to either:
+- Extend the retention of delegation-supporting audit evidence to match delegation lifetime, or
+- Expire delegations when their supporting evidence becomes unavailable
+
+This is intentional. The prior state allowed a system to claim delegation traceability (DEL-3) while the evidence that would allow independent verification of that traceability was routinely deleted under standard retention policy.
+
+---
+
+## Sequence Context
+
+- 0.0.21 — Stress test; Scenario 4 identified the audit-retention vs delegation gap
+- 0.0.22 — Closed primary operational data boundary (OWN-9, OWN-10)
+- 0.0.23 — Closed service provider boundary (SVC-8, SVC-9)
+- 0.0.24 — Aligned protocol requirements with normative rule register (PROT-1 through PROT-5)
+- 0.0.25 — Established actor identity portability requirements (ACTOR-1 through ACTOR-6)
+- 0.0.26 — Established governing entity authenticity requirements (GEA-1 through GEA-6)
+- 0.0.27 — Defined audit resolution floor (AUD-1 through AUD-6)
+- 0.0.28 — Binds delegation authority to verifiable evidence lifetime (DCL-1 through DCL-6)
+
+---
+
+*Proposal 0.0.28 — Open for committee review.*

--- a/standards/conformance.md
+++ b/standards/conformance.md
@@ -1,7 +1,7 @@
 # LEBOSS Conformance
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.27
+**Updated Through:** proposal/0.0.28
 **Applies to:** LEBOSS Standard pre-v0.1.0 draft and later
 
 ---
@@ -234,6 +234,8 @@ A system **MUST NOT** be described as LEBOSS-compliant if any of the following c
 22. **Platform-dependent ownership** — the system defines or controls governing entity authority in a manner that makes it dependent on service provider accounts, platform-controlled identifiers, or system-generated constructs that do not represent the real-world entity they purport to govern; or permits a service provider to unilaterally modify, reassign, or revoke governing entity status without the authorization of the party the governing entity represents (LEBOSS-GEA-2, LEBOSS-GEA-3, LEBOSS-GEA-5).
 
 23. **Insufficient audit resolution** — the system produces audit records that satisfy recording requirements but omit the resource-level or operation-level detail required to verify whether governed actions were within authorized scope, or produces an audit corpus that an independent party cannot use to evaluate governed action legality without access to system state, internal nomenclature, or service provider cooperation (LEBOSS-AUD-3, LEBOSS-AUD-5, LEBOSS-AUD-6).
+
+24. **Unverifiable delegation chain lifetime** — the system maintains active delegation grants whose authority chain cannot be independently validated due to loss or expiration of supporting audit evidence, or treats system assertions as sufficient substitute for independently verifiable delegation evidence when that evidence is unavailable (LEBOSS-DCL-2, LEBOSS-DCL-4, LEBOSS-DCL-6).
 
 ---
 

--- a/standards/leboss-normative-rules.md
+++ b/standards/leboss-normative-rules.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.27
+**Updated Through:** proposal/0.0.28
 **Derived from:** [leboss-standard.md](leboss-standard.md)
 
 ---
@@ -35,6 +35,7 @@ Rules are identified as `LEBOSS-{group}-{number}` where group indicates the cate
 - `ACTOR` — Actor Identity Portability Rules
 - `GEA` — Governing Entity Authenticity Rules
 - `AUD` — Audit Resolution Requirements Rules
+- `DCL` — Delegation Chain Lifetime Rules
 
 ---
 
@@ -439,7 +440,8 @@ Verification MUST NOT be satisfied by documentation, policy declaration, or stat
 | Actor Identity Portability (ACTOR)      | 6 | 3  | 3  | — | — |
 | Governing Entity Authenticity (GEA)     | 6 | 3  | 3  | — | — |
 | Audit Resolution Requirements (AUD)     | 6 | 3  | 3  | — | — |
-| **Total**                           | **103** | **66** | **40** | **5** | **—** |
+| Delegation Chain Lifetime (DCL)         | 6 | 3  | 3  | — | — |
+| **Total**                           | **109** | **69** | **43** | **5** | **—** |
 
 ---
 
@@ -551,9 +553,37 @@ A conformant system MUST NOT satisfy audit recording requirements by producing r
 
 ---
 
+## Delegation Chain Lifetime Rules
+
+**LEBOSS-DCL-1**
+A delegation chain MUST remain independently verifiable for its entire active lifetime. Verifiability requires that the chain can be traced to a valid root governing entity grant through evidence that does not rely on assertions made by the implementing system or its service providers.
+*Source: §24*
+
+**LEBOSS-DCL-2**
+A conformant system MUST NOT maintain active delegation grants whose authority chain cannot be independently validated. A delegation chain that has become unverifiable — whether through loss of supporting audit evidence or any other cause — MUST be treated as having no valid authority.
+*Source: §24*
+
+**LEBOSS-DCL-3**
+The audit evidence supporting each step in a delegation chain MUST persist for at least as long as the delegation remains active. A delegation chain that outlives the verifiable record of its origin does not satisfy this standard.
+*Source: §24*
+
+**LEBOSS-DCL-4**
+A conformant system MUST NOT allow a delegation chain to remain active after the supporting audit records establishing the root governing entity grant have become unavailable or irrecoverable.
+*Source: §24*
+
+**LEBOSS-DCL-5**
+Loss of verifiability in any link of a delegation chain MUST propagate as a validity failure to all grants in that chain. A delegation chain is only as verifiable as its least-verified link.
+*Source: §24*
+
+**LEBOSS-DCL-6**
+A conformant system MUST NOT substitute its own assertions, internal state, or configuration as evidence of delegation authority when independent audit evidence is unavailable. System trust is not a substitute for independently verifiable evidence.
+*Source: §24*
+
+---
+
 ## Gaps Identified
 
-The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.27.
+The following requirements were identified as implied by the standard but not yet specified with sufficient precision to be enumerable as rules. Status reflects the current state of the specification through proposal 0.0.28.
 
 **GAP-1: Access Grant Format** — *Resolved in 0.0.3 and 0.0.4; normative standing formalized in 0.0.24*
 The standard requires that access grants specify scope, operations, duration, and purpose (LEBOSS-ACC-2). The Access Grant object (`standards/objects/access-grant.md`) defines the required fields. The Access Grant Protocol (`standards/leboss-access-grant-protocol.md`) defines issuance, validation, revocation, and expiration behavioral rules (LEBOSS-AGP-1 through AGP-17). These rules are incorporated as normative requirements under LEBOSS-PROT-1.
@@ -572,4 +602,4 @@ LEBOSS-CONT-1 through CONT-3 require succession support but no protocol exists f
 
 ---
 
-*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.27. The standard governs in all cases of conflict.*
+*LEBOSS Normative Rule Register — pre-v0.1.0 draft, updated through proposal/0.0.28. The standard governs in all cases of conflict.*

--- a/standards/leboss-standard.md
+++ b/standards/leboss-standard.md
@@ -3,7 +3,7 @@
 
 **Status:** Draft
 **Target Release:** v0.1.0
-**Updated Through:** proposal/0.0.27
+**Updated Through:** proposal/0.0.28
 **Supersedes:** [leboss-standard-0.0.1.md](leboss-standard-0.0.1.md)
 
 ---
@@ -16,13 +16,13 @@ This document represents the integrated working draft of the LEBOSS standard pri
 
 Future revisions of the specification will be introduced through the proposal process defined in [governance/governance.md](../governance/governance.md).
 
-The proposal history for this version spans proposals 0.0.1 through 0.0.27, preserved in [`proposals/`](../proposals/).
+The proposal history for this version spans proposals 0.0.1 through 0.0.28, preserved in [`proposals/`](../proposals/).
 
 Normative language in this specification follows RFC conventions and appears only in documents contained in the `standards/` directory.
 
 ---
 
-> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.27. For change history, see the `proposals/` directory. For version metadata, see git tags.*
+> *This is the living LEBOSS specification. It incorporates all content from proposals 0.0.1 through 0.0.28. For change history, see the `proposals/` directory. For version metadata, see git tags.*
 
 ---
 
@@ -80,6 +80,7 @@ Items deferred beyond v0.1.0 are tracked in [STATUS.md](../STATUS.md).
 21. [Actor Identity Portability](#21-actor-identity-portability)
 22. [Governing Entity Authenticity](#22-governing-entity-authenticity)
 23. [Audit Resolution Requirements](#23-audit-resolution-requirements)
+24. [Delegation Chain Lifetime Integrity](#24-delegation-chain-lifetime-integrity)
 
 ---
 
@@ -552,7 +553,7 @@ Where conflicts exist between LEBOSS requirements and applicable law, applicable
 
 ## 10. Versioning
 
-This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.27.
+This document is the pre-v0.1.0 working draft of the LEBOSS Standard, updated through proposal/0.0.28.
 
 LEBOSS versions follow the pattern `X.Y.Z`:
 
@@ -902,4 +903,29 @@ The normative rules for audit resolution requirements (LEBOSS-AUD-1 through AUD-
 
 ---
 
-*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.27 — Open for community review and pull request contribution.*
+## 24. Delegation Chain Lifetime Integrity
+
+The LEBOSS delegation model requires that every delegation chain be traceable to a valid root governing entity grant (DEL-3). This traceability requirement is structural: it governs the form of the chain at the time it is created and evaluated. It does not govern how long the evidence supporting that evaluation must remain available.
+
+The result is a temporal gap. A delegation chain can be structurally correct at issuance — fully traced, properly scoped, referencing all originating grants — while the audit records that would allow an independent party to verify that structure expire under normal retention policy. When those records are gone, the chain can still be asserted by the system. It cannot be independently confirmed.
+
+**The gap this section addresses:** The DEL rules establish that delegation must be traceable. They do not establish that traceability must be independently demonstrable for as long as the delegation is active. A governing entity who wishes to audit an active delegation chain — or an independent evaluator verifying compliance — may find that the foundational records proving the chain's legitimacy no longer exist, while the delegation itself continues to authorize access on the governing entity's behalf.
+
+This is a meaningful accountability failure. The purpose of DEL-3 is to ensure that authority is always traceable to the governing entity's actual authorization. That purpose is defeated if the evidence supporting that traceability is routinely deleted while the authority it supports remains active.
+
+This section establishes the relationship between delegation authority and its evidentiary basis: a delegation chain may not remain active beyond the point at which it can be independently verified. This section does not define retention durations, storage mechanisms, archival strategies, or implementation approaches for maintaining delegation evidence.
+
+**Key behavioral requirements:**
+
+- A delegation chain **MUST** remain independently verifiable for its entire active lifetime — the chain must be traceable to a valid root governing entity grant through evidence that does not rely on system assertions (LEBOSS-DCL-1).
+- A conformant system **MUST NOT** maintain active delegation grants whose authority chain cannot be independently validated. An unverifiable chain **MUST** be treated as having no valid authority (LEBOSS-DCL-2).
+- The audit evidence supporting each step in a delegation chain **MUST** persist for at least as long as the delegation remains active (LEBOSS-DCL-3).
+- A conformant system **MUST NOT** allow a delegation chain to remain active after the supporting audit records establishing the root governing entity grant have become unavailable or irrecoverable (LEBOSS-DCL-4).
+- Loss of verifiability in any link of a delegation chain **MUST** propagate as a validity failure to all grants in that chain (LEBOSS-DCL-5).
+- A conformant system **MUST NOT** substitute its own assertions, internal state, or configuration as evidence of delegation authority when independent audit evidence is unavailable (LEBOSS-DCL-6).
+
+The normative rules for delegation chain lifetime integrity (LEBOSS-DCL-1 through DCL-6) are defined in [`standards/leboss-normative-rules.md`](leboss-normative-rules.md).
+
+---
+
+*LEBOSS Standard — pre-v0.1.0 draft, updated through proposal/0.0.28 — Open for community review and pull request contribution.*


### PR DESCRIPTION
## Summary

Closes the audit-retention vs delegation gap identified in the 0.0.21 stress test (Scenario 4).

The DEL rules require delegation chains to be traceable to a root governing entity grant (DEL-3). But traceability is a structural check evaluated against the system's internal state. It does not require that the audit evidence supporting that traceability persist for as long as the delegation is active. Under standard retention policy, audit records proving the root grant can expire while the delegation chain remains active — leaving the chain structurally asserted but independently unverifiable.

This proposal introduces **LEBOSS-DCL-1 through DCL-6**, a new `DCL` rule group that binds delegation authority to the continued existence of its verifiable evidentiary basis.

## Changes

- **`standards/leboss-normative-rules.md`** — Add `DCL` group (6 rules); update Rule Numbering, Summary Counts (103 → 109), Gaps section header, and footer
- **`standards/leboss-standard.md`** — Add §24 Delegation Chain Lifetime Integrity; update ToC, version stamps throughout
- **`standards/conformance.md`** — Add condition 24 (Unverifiable delegation chain lifetime); update header
- **`proposals/0.0.28/proposal.md`** — New proposal document

## Rule Count

| | Before | After |
|---|---|---|
| Total | 103 | 109 |
| MUST | 66 | 69 |
| MUST NOT | 40 | 43 |
| MAY | 5 | 5 |

## New Rules

- **DCL-1** (MUST): Delegation chain must remain independently verifiable for its entire active lifetime
- **DCL-2** (MUST NOT): Must not maintain active delegation chains that cannot be independently validated
- **DCL-3** (MUST): Audit evidence supporting each delegation step must persist as long as the delegation is active
- **DCL-4** (MUST NOT): Must not allow delegation chain to remain active after root grant audit records become unavailable
- **DCL-5** (MUST): Loss of verifiability in any link propagates as validity failure to the entire chain
- **DCL-6** (MUST NOT): Must not substitute system assertions for independently verifiable evidence

## Non-Conformance Condition Added

Condition 24 — **Unverifiable delegation chain lifetime**: active delegation whose authority chain cannot be independently validated due to loss of supporting audit evidence, or system assertions used as substitute for independent evidence (LEBOSS-DCL-2, LEBOSS-DCL-4, LEBOSS-DCL-6).

## Scope Boundaries

No retention durations, storage mechanisms, archival strategies, or implementation-specific persistence methods defined. The standard governs the relationship between delegation authority and its evidentiary basis; how that basis is maintained is an implementation concern.