### PR TITLE
docs: documentation alignment (0.0.30)

### DIFF
--- a/charter/mission.md
+++ b/charter/mission.md
@@ -1,7 +1,7 @@
 # LEBOSS Charter and Mission
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.11
+**Updated Through:** proposal/0.0.29
 
 ---
 
@@ -23,12 +23,18 @@ We believe a standard — shared, open, freely adoptable — is the most durable
 
 ## What LEBOSS Is
 
-LEBOSS — the **Local Entrepreneur Business Operating System Standards** — is an open standard that defines:
+LEBOSS — the **Local Entrepreneur Business Operating System Standards** — is an open standard that defines the governance layer for local business data systems:
 
 - How the digital operations of a local business should be organized
 - Who owns the data within that organization
 - What obligations service providers accept when they are granted access to that data
+- How access must be granted, scoped, delegated, and revoked
+- What governed actions must be audited and what detail those records must contain
+- How the complete operational data environment must be exportable on demand
+- How conformance claims must be evaluated and verified
 - How systems must be built to make ownership real rather than nominal
+
+LEBOSS defines the governance layer — the rules for ownership, access control, delegation, enforcement, audit, portability, and verification. These areas are fully specified in the current standard. What LEBOSS does not define is implementation: runtime environments, infrastructure platforms, API designs, or specific software architectures are outside the scope of the standard.
 
 LEBOSS is not a product. It is not a certification body. It is not a trade association. It is a standard — published openly, maintained by a community, and freely available for adoption, implementation, critique, and improvement.
 
@@ -50,7 +56,7 @@ LEBOSS is not a legal framework. It does not create rights or impose obligations
 
 This mission is pursued through:
 
-1. **Publication of the Standard** — An open, versioned specification that defines the LEBOSS architecture, data ownership doctrine, and service provider responsibilities
+1. **Publication of the Standard** — An open, versioned specification that defines the LEBOSS architecture, data ownership doctrine, access control model, delegation requirements, enforcement obligations, audit resolution standards, data portability requirements, and conformance criteria
 2. **Community Governance** — A transparent process by which the standard is proposed, debated, amended, and published by a community of contributors
 3. **Adoption and Implementation** — Encouraging developers, agencies, and service providers to build systems that align with the standard
 

--- a/glossary/terms.md
+++ b/glossary/terms.md
@@ -1,7 +1,7 @@
 # LEBOSS Glossary of Terms
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.23
+**Updated Through:** proposal/0.0.29
 
 ---
 
@@ -28,6 +28,16 @@ Full object definition: [`standards/objects/access-grant.md`](../standards/objec
 A party that performs a governed action within a LEBOSS-compliant system. An actor is identified by a stable, unique identifier recorded in the `actor_id` field of every Audit Record. Actors include human users, service accounts, automation processes, and external integrations. Every governed operation must be attributable to an actor.
 
 See also: *Audit Record*, *Governing Entity*
+
+---
+
+## Actor Identity
+
+The stable, portable identity of an actor within a LEBOSS-governed environment. Actor identity requirements mandate that actor identifiers be unique within a governed environment, stable across sessions and operations, and that no actor may assume another actor's identifier. An actor's identity must be consistently represented in all Audit Records produced by that actor's governed actions. Identity portability requires that actor identifiers remain valid and traceable across environment migrations.
+
+Normative rules: LEBOSS-ACTOR-1 through ACTOR-6.
+
+See also: *Actor*, *Audit Record*, *Identity Portability*
 
 ---
 
@@ -80,6 +90,18 @@ The requirement that Audit Records be preserved for a minimum defined period fol
 See also: *Audit Record*, *Audit Event*
 
 Full retention rules: [`standards/leboss-audit-protocol.md`](../standards/leboss-audit-protocol.md)
+
+---
+
+## Audit Resolution
+
+The informational floor that audit records must meet to serve their governance function. An audit record satisfies audit resolution requirements when it contains sufficient detail to determine: what specific resources were accessed or affected, what operation was performed, the outcome of that operation, and whether the access described was within the scope of the applicable Access Grant.
+
+Audit records that document event occurrence without resource-level and operation-level detail satisfy recording requirements but fail audit resolution requirements. An audit corpus that requires access to system state, internal nomenclature, or service provider cooperation to interpret does not satisfy this standard.
+
+Normative rules: LEBOSS-AUD-1 through AUD-6.
+
+See also: *Audit Record*, *Audit Trail*, *Conformance Evidence*, *System of Record*
 
 ---
 
@@ -205,6 +227,18 @@ See also: *Authority Chain*, *Access Grant*, *Governing Entity*
 
 ---
 
+## Delegation Chain
+
+The sequence of delegated grants tracing from the acting party back to the root governing entity grant. A delegation chain must be independently verifiable for its entire active lifetime: the audit evidence supporting each step must persist for at least as long as the delegation remains active. A delegation chain that has become unverifiable — whether through loss of supporting audit evidence or any other cause — must be treated as having no valid authority.
+
+A delegation chain is only as verifiable as its least-verified link. Loss of verifiability in any link propagates as a validity failure to all grants in the chain. A conformant system must not substitute its own assertions, internal state, or configuration as evidence of delegation authority when independent audit evidence is unavailable.
+
+Normative rules: LEBOSS-DCL-1 through DCL-6.
+
+See also: *Authority Chain*, *Delegated Grant*, *Access Grant*, *Audit Record*
+
+---
+
 ## Data Fiduciary
 
 A party who holds and manages data on behalf of another party, under an obligation to act in the interests of the data's rightful owner. In the LEBOSS model, service providers who access primary operational data are expected to act as data fiduciaries.
@@ -323,6 +357,18 @@ See also: *Universe (Element 0)*
 
 ---
 
+## Governing Entity Authenticity
+
+The requirement that a party claiming to act as a governing entity in a LEBOSS-compliant system be verifiably identifiable as the actual governing entity. A conformant system must not accept or act on governing entity assertions that are unverifiable, externally asserted without internal verification, or that conflict with the established governing entity identity for the governed environment.
+
+Governed actions taken on the basis of an unauthenticated governing entity claim are not authorized. A governing entity credential or assertion that cannot be independently verified does not satisfy this standard.
+
+Normative rules: LEBOSS-GEA-1 through GEA-6.
+
+See also: *Governing Entity*, *Actor Identity*, *Conformance Evidence*
+
+---
+
 ## Integration Descriptor
 
 A governance object that records the authorization of an external integration to receive data from a LEBOSS-compliant system. An Integration Descriptor must exist before any external integration may receive primary operational data.
@@ -395,9 +441,13 @@ See also: *Access Grant*, *Grant Revocation*, *Grant Validation*
 
 ## Grant Revocation
 
-The immediate, permanent invalidation of an Access Grant by the governing entity. Revocation takes effect at the moment it is issued and must be reflected in all system components without delay. A revoked grant cannot be reactivated — new access requires a new grant.
+The immediate, permanent invalidation of an Access Grant by the governing entity. Revocation is effective at the moment it occurs — no governed action may be authorized under a revoked grant for any reason. A revoked grant cannot be reactivated — new access requires a new grant.
+
+A conformant system must evaluate grant state using authoritative, current grant state at the time of access evaluation. Enforcement based on cached, stale, or previously recorded authorization state when the current authoritative state of the grant is revoked does not satisfy this standard.
 
 Revocation is a core enforcement mechanism for the governing entity's right to control data access. It must be technically supported in any LEBOSS-compliant system, not merely contractually promised.
+
+Normative rules: LEBOSS-ACC-3, LEBOSS-REV-1 through REV-6.
 
 See also: *Access Grant*, *Grant Lifecycle*
 

--- a/governance/governance.md
+++ b/governance/governance.md
@@ -1,7 +1,7 @@
 # LEBOSS Governance Model
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.11
+**Updated Through:** proposal/0.0.29
 
 ---
 
@@ -96,7 +96,7 @@ LEBOSS versions follow the pattern `X.Y.Z`, where each position has a specific m
 1.0.0  →  Members ratify; canonical standard published
 ```
 
-The current standard is the pre-v0.1.0 working draft, updated through proposal/0.0.12 — open for community contribution and pull requests.
+The current standard is the pre-v0.1.0 working draft, updated through proposal/0.0.29 — open for community contribution and pull requests.
 
 ---
 

--- a/presentations/slidev/architecture.md
+++ b/presentations/slidev/architecture.md
@@ -468,7 +468,7 @@ class: text-center
     <li>• Access Grants MUST be issued only by the governing entity</li>
     <li>• Access Grants MUST be revocable at any time</li>
     <li>• No data access is permitted without a valid, active Access Grant</li>
-    <li>• Revocation MUST take effect within a defined maximum latency</li>
+    <li>• Revocation is effective at the moment it occurs — no governed action may proceed under a revoked grant</li>
     <li>• Every grant issuance, suspension, and revocation MUST produce an Audit Record</li>
   </ul>
 </div>

--- a/presentations/slidev/governance.md
+++ b/presentations/slidev/governance.md
@@ -302,7 +302,7 @@ class: text-center
   <div class="text-5xl font-bold text-blue-300 mb-2">Z</div>
   <div class="text-sm font-semibold mb-2">Draft</div>
   <div class="text-xs text-gray-400">Rightmost digit. Increments with each accepted Proposal. Working drafts open to community feedback.</div>
-  <div class="mt-3 text-xs text-blue-300 font-mono">0.0.1 → 0.0.2 → 0.0.12</div>
+  <div class="mt-3 text-xs text-blue-300 font-mono">0.0.1 → 0.0.2 → 0.0.29</div>
 </div>
 
 <div class="bg-purple-900 bg-opacity-40 border border-purple-500 rounded-xl p-5 text-center">
@@ -323,7 +323,7 @@ class: text-center
 
 <div class="bg-white bg-opacity-5 rounded-lg p-4 text-sm">
   <strong class="text-gray-300">Current status:</strong>
-  <span class="text-gray-400"> LEBOSS is at <code class="text-blue-300">0.0.12</code> — a complete working draft preparing for <code class="text-purple-300">0.1.0</code>, the first Committee Vote candidate. Proposals 0.0.1 through 0.0.12 are open for community review.</span>
+  <span class="text-gray-400"> LEBOSS is at <code class="text-blue-300">0.0.29</code> — a comprehensive working draft covering ownership, access control, delegation, enforcement, audit, portability, and verification. Open for community review.</span>
 </div>
 
 </div>
@@ -449,19 +449,32 @@ class: text-center
 
 <div class="bg-white bg-opacity-5 rounded-lg p-4">
   <h3 class="font-semibold text-blue-300 mb-2">What conformance means</h3>
-  <p class="text-gray-400">A LEBOSS-compliant system implements all MUST-level requirements in the normative rule register. The register contains normative rules across 6 groups, corresponding to the governance protocols in the standard.</p>
+  <p class="text-gray-400">A LEBOSS-compliant system implements all MUST-level requirements in the normative rule register. The register contains 115 normative rules across 19 rule groups, spanning ownership, access control, delegation, enforcement, audit, portability, and verification.</p>
 </div>
 
 <div class="bg-white bg-opacity-5 rounded-lg p-4">
   <h3 class="font-semibold text-purple-300 mb-2">Rule groups</h3>
-  <ul class="text-gray-400 space-y-1">
-    <li>• <code class="text-blue-300">LEBOSS-AGP</code> — Access Grant Protocol</li>
-    <li>• <code class="text-blue-300">LEBOSS-IDP</code> — Integration Descriptor Protocol</li>
-    <li>• <code class="text-blue-300">LEBOSS-ACP</code> — Audit Record Collection Protocol</li>
-    <li>• <code class="text-blue-300">LEBOSS-DPP</code> — Data Portability Protocol</li>
-    <li>• <code class="text-blue-300">LEBOSS-RM</code> — Resource Model</li>
-    <li>• <code class="text-blue-300">LEBOSS-GOV</code> — Governance Objects</li>
-  </ul>
+  <div class="grid grid-cols-2 gap-x-4 gap-y-1 text-gray-400 text-xs">
+    <div>• <code class="text-blue-300">OWN</code> — Ownership</div>
+    <div>• <code class="text-blue-300">ACC</code> — Access Control</div>
+    <div>• <code class="text-blue-300">ARCH</code> — Architecture</div>
+    <div>• <code class="text-blue-300">SEC</code> — Security</div>
+    <div>• <code class="text-blue-300">CONT</code> — Continuity</div>
+    <div>• <code class="text-blue-300">SVC</code> — Service Providers</div>
+    <div>• <code class="text-blue-300">SPEC</code> — Specification Boundary</div>
+    <div>• <code class="text-blue-300">ENF</code> — Enforcement</div>
+    <div>• <code class="text-blue-300">REC</code> — Record Keeping</div>
+    <div>• <code class="text-blue-300">PORT</code> — Portability</div>
+    <div>• <code class="text-blue-300">MAP</code> — Resource Mapping</div>
+    <div>• <code class="text-blue-300">DEL</code> — Delegation</div>
+    <div>• <code class="text-blue-300">VER</code> — Verification</div>
+    <div>• <code class="text-blue-300">PROT</code> — Protocol Normativity</div>
+    <div>• <code class="text-blue-300">ACTOR</code> — Actor Identity</div>
+    <div>• <code class="text-blue-300">GEA</code> — Governing Entity Auth</div>
+    <div>• <code class="text-blue-300">AUD</code> — Audit Resolution</div>
+    <div>• <code class="text-blue-300">DCL</code> — Delegation Chain Lifetime</div>
+    <div>• <code class="text-blue-300">REV</code> — Revocation Enforcement</div>
+  </div>
 </div>
 
 </div>
@@ -475,7 +488,7 @@ class: text-center
 
 <div class="bg-white bg-opacity-5 rounded-lg p-4">
   <h3 class="font-semibold text-yellow-300 mb-2">Conformance criteria</h3>
-  <p class="text-gray-400">Formal third-party conformance criteria are on the roadmap. Until established, implementations should document which rules they implement and provide evidence for each MUST-level requirement.</p>
+  <p class="text-gray-400">Conformance is self-declared. The specification provides normative precision sufficient for an independent auditor to verify compliance claims against the rule register. Implementations should document which rules they implement and provide observable evidence for each MUST-level requirement.</p>
 </div>
 
 </div>


### PR DESCRIPTION
## Summary

- Brings all existing documentation into alignment with LEBOSS standard through proposal/0.0.29
- No new normative content introduced — corrections and normalization only

## Files Updated

**`charter/mission.md`**
- Version stamp updated: `proposal/0.0.11` → `proposal/0.0.29`
- Expanded "What LEBOSS Is" to explicitly enumerate the full governance scope (ownership, access control, delegation, enforcement, audit, portability, verification)
- Added explicit statement that LEBOSS defines the governance layer and that these areas are fully specified
- Updated mission description to name the complete standard scope

**`glossary/terms.md`**
- Version stamp updated: `proposal/0.0.23` → `proposal/0.0.29`
- Added `Actor Identity` entry (ACTOR-1 through ACTOR-6, from 0.0.25)
- Added `Audit Resolution` entry (AUD-1 through AUD-6, from 0.0.27)
- Added `Delegation Chain` entry (DCL-1 through DCL-6, from 0.0.28)
- Added `Governing Entity Authenticity` entry (GEA-1 through GEA-6, from 0.0.26)
- Updated `Grant Revocation` to cite REV-1 through REV-6 and reflect that revocation is effective at the moment it occurs (not merely "without delay")

**`governance/governance.md`**
- Version stamp updated: `proposal/0.0.11` → `proposal/0.0.29`
- Version reference updated: `proposal/0.0.12` → `proposal/0.0.29`

**`presentations/slidev/governance.md`**
- Version references updated: `0.0.12` → `0.0.29` throughout
- Conformance slide: replaced outdated 6-group rule list with accurate 19-group listing (OWN, ACC, ARCH, SEC, CONT, SVC, SPEC, ENF, REC, PORT, MAP, DEL, VER, PROT, ACTOR, GEA, AUD, DCL, REV)
- Updated rule count from "6 groups" to "115 normative rules across 19 rule groups"
- Removed "on the roadmap" language from conformance criteria — replaced with definitive language

**`presentations/slidev/architecture.md`**
- Corrected Access Grants slide: "Revocation MUST take effect within a defined maximum latency" → "Revocation is effective at the moment it occurs" (aligns with LEBOSS-REV-4)

## Normative content not changed

No normative rules, conformance conditions, or standard sections were modified.