### PR TITLE
docs: system-wide documentation alignment (0.0.30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 **Local Entrepreneur Business Operating System Standards**
 
+**Updated Through:** proposal/0.0.29
+
 [![Version](https://img.shields.io/badge/version-pre--v0.1.0-blue)](STATUS.md)
 [![Status](https://img.shields.io/badge/status-draft-orange)](STATUS.md)
 [![Type](https://img.shields.io/badge/type-open%20standard-purple)](standards/leboss-standard.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 
-> An open governance standard for defining clear system ownership boundaries, integration contracts, and auditable data access — for local business software systems.
+> An open governance standard defining ownership, access control, delegation, enforcement, audit, portability, identity, and revocation requirements for local business data systems.
 
 See [STATUS.md](STATUS.md) for current specification status and release information.
 
@@ -87,7 +89,7 @@ The **Governing Entity** (Universe) owns all data. Every other element operates 
 |----------|---------|
 | [standards/leboss-standard.md](standards/leboss-standard.md) | Base standard — reference model, data ownership doctrine, service provider obligations, conformance |
 | [standards/conformance.md](standards/conformance.md) | Conformance definition — minimum requirements for LEBOSS-compliant implementations |
-| [standards/leboss-normative-rules.md](standards/leboss-normative-rules.md) | Flat rule register — 40 normative rules across 6 protocol groups |
+| [standards/leboss-normative-rules.md](standards/leboss-normative-rules.md) | Flat rule register — 115 normative rules across 19 rule groups |
 | [standards/leboss-resource-model.md](standards/leboss-resource-model.md) | Resource Model |
 | [standards/leboss-access-grant-protocol.md](standards/leboss-access-grant-protocol.md) | Access Grant Protocol |
 | [standards/leboss-integration-protocol.md](standards/leboss-integration-protocol.md) | Integration Descriptor Protocol |
@@ -106,7 +108,7 @@ The **Governing Entity** (Universe) owns all data. Every other element operates 
 | [`standards/`](standards/) | Normative specification — all MUST/SHOULD/MAY requirements |
 | [`glossary/`](glossary/) | Canonical terminology definitions |
 | [`governance/`](governance/) | Governance model — proposal lifecycle, committee roles |
-| [`proposals/`](proposals/) | Specification change history (0.0.1 → 0.0.12) |
+| [`proposals/`](proposals/) | Specification change history (0.0.1 → 0.0.29) |
 | [`presentations/`](presentations/) | Three-deck Slidev presentation portal |
 | [`charter/`](charter/) | Mission and philosophical foundation |
 
@@ -160,21 +162,15 @@ Every pull request automatically generates a **Netlify preview** of the presenta
 
 ## Current Status
 
-The specification is at the **pre-v0.1.0 draft** milestone — the first implementable draft. The architecture, governance objects, and operational protocols are draft-stable.
+The specification is at the **pre-v0.1.0 draft** milestone — structurally complete and open for community contribution. The standard covers the full governance layer across 115 normative rules and 19 rule groups. All boundary gaps identified in the 0.0.21 stress test have been resolved.
 
-| Proposal | Content |
-|----------|---------|
-| [0.0.1](proposals/0.0.1/proposal.md) | Initial doctrine and reference architecture |
-| [0.0.2](proposals/0.0.2/proposal.md) | Normative rule register and formalization pass |
-| [0.0.3](proposals/0.0.3/proposal.md) | Governance object model |
-| [0.0.4](proposals/0.0.4/proposal.md) | Access Grant Protocol |
-| [0.0.5](proposals/0.0.5/proposal.md) | Integration Descriptor Protocol |
-| [0.0.6](proposals/0.0.6/proposal.md) | Audit Record Collection Protocol |
-| [0.0.7](proposals/0.0.7/proposal.md) | Data Portability Protocol |
-| [0.0.8](proposals/0.0.8/proposal.md) | Resource Model |
-| [0.0.9](proposals/0.0.9/proposal.md) | Specification stabilization |
-| [0.0.10](proposals/0.0.10/proposal.md) | Repository normalization |
-| [0.0.11](proposals/0.0.11/proposal.md) | Canonical presentation system |
+**Foundation (0.0.1–0.0.12):** Initial doctrine, normative rule register, governance object model, five operational protocols, resource model, conformance requirements, and terminology stabilization.
+
+**Governance boundary and enforcement (0.0.13–0.0.20):** Specification and implementation boundary defined; enforcement responsibility, audit as system of record, portability format requirements, resource identity mapping, delegation constraints, conformance verification, and structural normalization.
+
+**Stress test and gap closure (0.0.21–0.0.29):** Boundary stress test identified enforcement gaps; primary operational data boundary (OWN-9–10), service provider boundary (SVC-8–9), protocol normativity alignment (PROT-1–5), actor identity portability (ACTOR-1–6), governing entity authenticity (GEA-1–6), audit resolution requirements (AUD-1–6), delegation chain lifetime integrity (DCL-1–6), and revocation enforcement timing (REV-1–6).
+
+Full proposal history is in [`proposals/`](proposals/) and in [STATUS.md](STATUS.md).
 
 The next milestone is **v0.1.0** — the first Committee Vote candidate.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,7 @@
 # LEBOSS Releases
 
+**Updated Through:** proposal/0.0.29
+
 This document describes the versioning policy for the LEBOSS specification and lists all releases.
 
 ---
@@ -15,7 +17,7 @@ LEBOSS uses semantic versioning in the form `X.Y.Z` with LEBOSS-specific meaning
 | `X` (leftmost) | **Published** | A committee- and member-ratified standard. Immutable. The canonical reference for conformant implementations. |
 
 **Examples:**
-- `0.0.12` — twelfth working draft; current pre-v0.1.0 draft
+- `0.0.29` — pre-v0.1.0 complete draft (post stress-test closure); structurally complete governance standard
 - `0.1.0` — first Committee Vote candidate; stable for implementer review
 - `1.0.0` — first Published standard; ratified and immutable
 
@@ -51,6 +53,8 @@ Specification versions are tracked through:
 
 ### Draft Releases
 
+#### Foundation Series (0.0.1–0.0.12)
+
 | Version | Tag | Proposal | Content |
 |---------|-----|----------|---------|
 | 0.0.1 | [`v0.0.1`](https://github.com/jwogrady/leboss/releases/tag/v0.0.1) | [proposals/0.0.1](proposals/0.0.1/proposal.md) | Initial doctrine and reference architecture |
@@ -66,11 +70,38 @@ Specification versions are tracked through:
 | 0.0.11 | [`v0.0.11`](https://github.com/jwogrady/leboss/releases/tag/v0.0.11) | [proposals/0.0.11](proposals/0.0.11/proposal.md) | Canonical multi-deck presentation system |
 | 0.0.12 | [`v0.0.12`](https://github.com/jwogrady/leboss/releases/tag/v0.0.12) | [proposals/0.0.12](proposals/0.0.12/proposal.md) | Terminology stabilization — conformance tiers, missing glossary entries, element name alignment |
 
+#### Governance Boundary and Enforcement Series (0.0.13–0.0.20)
+
+| Version | Proposal | Content |
+|---------|----------|---------|
+| 0.0.13 | [proposals/0.0.13](proposals/0.0.13/proposal.md) | Specification and implementation boundary |
+| 0.0.14 | [proposals/0.0.14](proposals/0.0.14/proposal.md) | Enforcement responsibility |
+| 0.0.15 | [proposals/0.0.15](proposals/0.0.15/proposal.md) | Audit as system of record |
+| 0.0.16 | [proposals/0.0.16](proposals/0.0.16/proposal.md) | Data portability format requirements |
+| 0.0.17 | [proposals/0.0.17](proposals/0.0.17/proposal.md) | Cross-system resource identity and mapping |
+| 0.0.18 | [proposals/0.0.18](proposals/0.0.18/proposal.md) | Delegation and authority chain constraints |
+| 0.0.19 | [proposals/0.0.19](proposals/0.0.19/proposal.md) | Conformance verification |
+| 0.0.20 | [proposals/0.0.20](proposals/0.0.20/proposal.md) | Structural normalization |
+
+#### Stress Test and Gap Closure Series (0.0.21–0.0.29)
+
+| Version | Proposal | Content |
+|---------|----------|---------|
+| 0.0.21 | [proposals/0.0.21](proposals/0.0.21/proposal.md) | Boundary stress test — identified remaining enforcement gaps |
+| 0.0.22 | [proposals/0.0.22](proposals/0.0.22/proposal.md) | Primary operational data boundary (OWN-9, OWN-10) |
+| 0.0.23 | [proposals/0.0.23](proposals/0.0.23/proposal.md) | Service provider boundary (SVC-8, SVC-9) |
+| 0.0.24 | [proposals/0.0.24](proposals/0.0.24/proposal.md) | Protocol normativity alignment (PROT-1 through PROT-5) |
+| 0.0.25 | [proposals/0.0.25](proposals/0.0.25/proposal.md) | Actor identity portability (ACTOR-1 through ACTOR-6) |
+| 0.0.26 | [proposals/0.0.26](proposals/0.0.26/proposal.md) | Governing entity authenticity (GEA-1 through GEA-6) |
+| 0.0.27 | [proposals/0.0.27](proposals/0.0.27/proposal.md) | Audit resolution requirements (AUD-1 through AUD-6) |
+| 0.0.28 | [proposals/0.0.28](proposals/0.0.28/proposal.md) | Delegation chain lifetime integrity (DCL-1 through DCL-6) |
+| 0.0.29 | [proposals/0.0.29](proposals/0.0.29/proposal.md) | Revocation enforcement timing (REV-1 through REV-6) |
+
 ### Upcoming
 
 | Version | Status | Description |
 |---------|--------|-------------|
-| **0.1.0** | Preparing | First Committee Vote candidate — implementable draft release |
+| **0.1.0** | Preparing | First Committee Vote candidate — structurally complete governance standard open for member ratification |
 
 ---
 
@@ -79,17 +110,11 @@ Specification versions are tracked through:
 Tags are applied to commits on the `master` branch after proposals are merged:
 
 ```
-git tag -a v0.1.0 -m "LEBOSS 0.1.0 — first implementable draft release"
+git tag -a v0.1.0 -m "LEBOSS 0.1.0 — first Committee Vote candidate"
 git push origin v0.1.0
 ```
 
 Each tag marks the state of the specification at that version. The full specification at any past version is recoverable by checking out the corresponding tag.
-
----
-
-## Open Gap
-
-**GAP-5: Succession and Ownership Transfer Protocol** — The standard requires succession support (LEBOSS-CONT-1 through CONT-3) but no protocol yet defines how ownership transfer is executed. This is the one remaining identified gap and is formally deferred beyond `0.1.0`.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,25 +1,39 @@
 # LEBOSS Specification Status
 
 **Current Version:** pre-v0.1.0 (Draft)
-**Updated Through:** proposal/0.0.12
+**Updated Through:** proposal/0.0.29
 **Next Milestone:** v0.1.0 — first Committee Vote candidate
 
 ---
 
 ## Specification Stability
 
-The architecture, governance object model, and operational protocols are considered **draft-stable** as of proposal/0.0.11.
+The architecture, governance object model, and operational protocols are **structurally complete** as of proposal/0.0.29.
 
-The v0.1.0 release represents the first implementable draft of the standard. Implementations may begin development against this version with the understanding that subsequent proposals may refine — but are not expected to break — the core governance model.
+The standard covers the full governance layer: ownership, access control, delegation, enforcement, audit, portability, identity, and revocation timing. All boundary gaps identified in the 0.0.21 stress test have been resolved through proposals 0.0.22–0.0.29.
 
-The following areas remain explicitly deferred to future proposals:
+- **115 normative rules** across **19 rule groups**
+- **25 non-conformance conditions** defined in `standards/conformance.md`
+- **MUST:** 72 · **MUST NOT:** 46 · **MAY:** 5
 
-- Formal compliance certification procedures and profiles
-- Ownership transfer and succession protocols
-- Satellite-specific compliance rules
-- Normative requirements for AI and machine learning use of primary operational data
-- A canonical LEBOSS Portability Format (specific encoding specification)
-- Technical API and interface specifications for compliant Planet implementations
+Implementations may begin development against this version. The pre-v0.1.0 draft is open for community contribution and critique. The v0.1.0 milestone will mark the first Committee Vote candidate.
+
+---
+
+## What the Standard Covers
+
+LEBOSS defines the governance layer for local business data systems:
+
+- **Ownership** — who owns the data; governing entity authority and obligations
+- **Access Control** — how access is granted, scoped, and enforced
+- **Delegation** — how authority is delegated and what constraints apply
+- **Enforcement** — when and how normative rules must be enforced
+- **Audit** — what governed actions must be recorded and at what resolution
+- **Portability** — how the complete operational data environment must be exportable
+- **Identity** — actor identity portability and governing entity authenticity
+- **Revocation Timing** — when revocation takes effect and what enforcement must reflect
+
+What the standard does not cover: runtime environments, infrastructure platforms, API designs, specific software architectures, or implementation patterns. These are outside the scope of the governance standard by design.
 
 ---
 
@@ -41,6 +55,23 @@ The specification evolved through the following proposals, each merged to `maste
 | [0.0.10](proposals/0.0.10/proposal.md) | Repository normalization and publishing preparation |
 | [0.0.11](proposals/0.0.11/proposal.md) | Canonical multi-deck presentation system |
 | [0.0.12](proposals/0.0.12/proposal.md) | Terminology stabilization — conformance tiers, missing glossary entries, element name alignment |
+| [0.0.13](proposals/0.0.13/proposal.md) | Specification and implementation boundary |
+| [0.0.14](proposals/0.0.14/proposal.md) | Enforcement responsibility |
+| [0.0.15](proposals/0.0.15/proposal.md) | Audit as system of record |
+| [0.0.16](proposals/0.0.16/proposal.md) | Data portability format requirements |
+| [0.0.17](proposals/0.0.17/proposal.md) | Cross-system resource identity and mapping |
+| [0.0.18](proposals/0.0.18/proposal.md) | Delegation and authority chain constraints |
+| [0.0.19](proposals/0.0.19/proposal.md) | Conformance verification |
+| [0.0.20](proposals/0.0.20/proposal.md) | Structural normalization |
+| [0.0.21](proposals/0.0.21/proposal.md) | Boundary stress test — identified remaining enforcement gaps |
+| [0.0.22](proposals/0.0.22/proposal.md) | Primary operational data boundary (OWN-9, OWN-10) |
+| [0.0.23](proposals/0.0.23/proposal.md) | Service provider boundary (SVC-8, SVC-9) |
+| [0.0.24](proposals/0.0.24/proposal.md) | Protocol normativity alignment (PROT-1 through PROT-5) |
+| [0.0.25](proposals/0.0.25/proposal.md) | Actor identity portability (ACTOR-1 through ACTOR-6) |
+| [0.0.26](proposals/0.0.26/proposal.md) | Governing entity authenticity (GEA-1 through GEA-6) |
+| [0.0.27](proposals/0.0.27/proposal.md) | Audit resolution requirements (AUD-1 through AUD-6) |
+| [0.0.28](proposals/0.0.28/proposal.md) | Delegation chain lifetime integrity (DCL-1 through DCL-6) |
+| [0.0.29](proposals/0.0.29/proposal.md) | Revocation enforcement timing (REV-1 through REV-6) |
 
 Proposal documents are preserved in [`proposals/`](proposals/) and serve as the permanent change log of the specification.
 

--- a/governance/committee.md
+++ b/governance/committee.md
@@ -1,7 +1,7 @@
 # LEBOSS Committee Structure
 
 **Status:** Draft
-**Updated Through:** proposal/0.0.11
+**Updated Through:** proposal/0.0.29
 
 ---
 
@@ -10,6 +10,8 @@
 The LEBOSS Committee exists to steward the standard — not to own it. Its members are accountable to the community of business owners, developers, and service providers who adopt and contribute to LEBOSS.
 
 The committee must remain small enough to move decisively and open enough to represent the interests of those it serves. It must never become a barrier to contribution or a mechanism for private control.
+
+As of proposal/0.0.29, the standard is structurally complete. The committee's primary work is now the maintenance and evolution of a comprehensive governance specification — reviewing proposals, ensuring coherence across 115 normative rules and 19 rule groups, and stewarding the path toward the first Committee Vote candidate (v0.1.0).
 
 ---
 
@@ -94,7 +96,7 @@ The committee will hold public discussion periods for all Drafts and will seek t
 
 ---
 
-## Current Committee (Founding)
+## Current Committee
 
 | Role | Name | Affiliation |
 |------|------|-------------|
@@ -102,7 +104,7 @@ The committee will hold public discussion periods for all Drafts and will seek t
 | Committee Member | *Open for nomination* | — |
 | Committee Member | *Open for nomination* | — |
 
-*This table will be populated as the founding committee is established. Nominations are open. See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to participate.*
+*Nominations are open. See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to participate.*
 
 ---
 


### PR DESCRIPTION
## Summary

- **STATUS.md** — Updated Through → 0.0.29; rewrote stability section to reflect structurally complete standard (115 rules, 19 groups, 25 non-conformance conditions); replaced deferred-items list with governance-layer scope description; extended proposal history table from 0.0.12 through 0.0.29
- **README.md** — Added Updated Through header; updated normative rules description from "40 rules across 6 groups" to "115 rules across 19 groups"; updated proposals history range; rewrote Current Status section with grouped proposal narrative
- **RELEASES.md** — Added Updated Through header; updated version example (0.0.12 → 0.0.29); restructured release table into three logical groups (Foundation 0.0.1–0.0.12, Governance Boundary 0.0.13–0.0.20, Stress Test and Gap Closure 0.0.21–0.0.29); removed stale Open Gap entry; updated Upcoming milestone description
- **governance/committee.md** — Updated Through → 0.0.29; added paragraph noting structurally complete standard and committee focus on maintenance and evolution; removed "Founding" framing from committee table header

## What changed

All four documents previously reflected the state of the standard at 0.0.11–0.0.12 — before the boundary stress test and before the 17 proposals that grew the standard from 78 rules to 115 across 19 rule groups. This pass eliminates all stale version references and brings positioning into alignment with the current standard.

No normative content changed. No new concepts introduced. Corrections and normalization only.