### PR TITLE
docs: presentation alignment (v0.1.0-rc)

### DIFF
--- a/presentations/slidev/overview.md
+++ b/presentations/slidev/overview.md
@@ -453,7 +453,7 @@ layout: two-cols
   <div class="w-2 h-2 bg-blue-400 rounded-full mt-1.5 flex-shrink-0"></div>
   <div>
     <strong class="text-blue-300">Clear governance model</strong>
-    <p class="text-gray-400 text-xs mt-1">A comprehensive set of normative rules across multiple protocol groups — a precise implementation target.</p>
+    <p class="text-gray-400 text-xs mt-1">115 normative rules across 19 rule groups — a precise, version-stable implementation target.</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary

- Audited all three active presentation decks (`overview.md`, `architecture.md`, `governance.md`) for v0.1.0-rc alignment
- Updated overview deck "For Developers" card: replaced vague "comprehensive set of normative rules across multiple protocol groups" with the accurate count — **115 normative rules across 19 rule groups**
- `architecture.md` and `governance.md` were already fully aligned from the prior comprehensive audit (PR #36); no changes needed

## Scope

Non-normative documentation update only. No standards content modified.