### PR TITLE
Docs glow-up: README rewrite, philosophy, Diátaxis guides, changelog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .env
 .bolt
 .claude
+.docit-notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,172 @@
+# Changelog
+
+All notable changes to the LEBOSS Standard are documented here.
+
+This is the concise running log. For the full versioning policy, the governance
+workflow, and the per-proposal narrative, see [`RELEASES.md`](RELEASES.md) — the two
+documents complement each other and do not contradict.
+
+The standard follows semantic versioning with LEBOSS-specific meaning: **Z = Draft**,
+**Y = Committee Vote**, **X = Published**. See
+[Understanding the Version Scheme](#understanding-the-version-scheme) below. The
+format takes its cues from [Keep a Changelog](https://keepachangelog.com/).
+
+> **Tag note.** Git tags currently exist only for **v0.0.1 through v0.0.11**.
+> Proposals 0.0.12 through 0.0.29 are merged to `master` and documented in
+> [`RELEASES.md`](RELEASES.md) and the `proposals/` directory, but are not yet tagged.
+
+---
+
+## [Unreleased]
+
+### Added
+
+- CC BY 4.0 license file ([`LICENSE`](LICENSE)) for the specification and materials.
+- `AGENTS.md` and an extended `CLAUDE.md` defining the repository's agent contract.
+
+### Notes
+
+- Proposal 0.0.29 is merged to `master`; no git tag has been applied yet.
+- Tags v0.0.12–v0.0.29 are not yet applied. Backfilling them, or correcting the tag
+  references in `RELEASES.md`, is tracked as a roadmap item — not a blocker.
+
+---
+
+## [v0.1.0-rc] — Release Candidate for the First Committee Vote — unreleased
+
+**Status:** structurally complete; open for community review and committee
+consideration. Updated through `proposal/0.0.29` (Revocation Enforcement Timing).
+
+- **115 normative rules** across **19 rule groups**; **25 non-conformance conditions**.
+- The architecture, governance object model, and operational protocols are
+  structurally complete. The five gap areas surfaced by the 0.0.21 boundary stress
+  test have been resolved.
+- Not yet voted. The committee is not yet appointed; no vote has been called.
+- Not yet implemented. `IMPLEMENTATIONS.md` is empty.
+- Conformance is self-declared. No third-party certification program exists in this
+  version.
+
+---
+
+## The 0.0.1 → 0.0.29 Journey
+
+The release-candidate version was reached over twenty-nine proposals, preserved one
+directory per proposal under `proposals/`. They group into three phases.
+
+### Foundation (0.0.1 – 0.0.12)
+
+Established the standards body, the reference model, the governance objects, and the
+protocols. *(Tags exist for v0.0.1 through v0.0.11. Proposal 0.0.12 is merged but
+untagged.)*
+
+- **0.0.1** — Initial doctrine and reference architecture
+  (Universe → Galaxy → Star ↔ Planet → Moon/Satellite).
+- **0.0.2** — Normative rule register: moved from prose to a structured rule register.
+- **0.0.3** — Governance object model: Access Grant, Integration Descriptor, Audit
+  Record.
+- **0.0.4** — Access Grant Protocol.
+- **0.0.5** — Integration Descriptor Protocol.
+- **0.0.6** — Audit Record Collection Protocol.
+- **0.0.7** — Data Portability Protocol.
+- **0.0.8** — Resource Model: resource identity and ownership mapping.
+- **0.0.9** — Specification stabilization: structure locked.
+- **0.0.10** — Repository normalization (file structure, README, deployment).
+- **0.0.11** — Canonical multi-deck presentation system
+  (Slidev: Overview, Architecture, Governance).
+- **0.0.12** — Terminology stabilization: formalized the two-tier conformance model
+  (LEBOSS-aligned vs LEBOSS-compliant), resolved undefined terms, aligned element
+  names. *(First untagged proposal.)*
+
+### Governance Boundary and Enforcement (0.0.13 – 0.0.20)
+
+Clarified the specification/implementation boundary and enforcement responsibility.
+*(Untagged.)*
+
+- **0.0.13** — Specification and implementation boundary: what LEBOSS normatively
+  covers (ownership, governance) versus what it defers (infrastructure, APIs,
+  databases).
+- **0.0.14** — Enforcement responsibility: who enforces each rule.
+- **0.0.15** — Audit as system of record: canonical truth lives in the audit trail,
+  not in operational state.
+- **0.0.16** — Data portability format requirements: export format, manifest
+  structure, non-proprietary requirements.
+- **0.0.17** — Cross-system resource identity and mapping.
+- **0.0.18** — Delegation and authority chain constraints: scope, lifetime,
+  propagation of delegated access.
+- **0.0.19** — Conformance verification: self-declaration model, non-conformance
+  condition mapping.
+- **0.0.20** — Structural normalization: eliminated cross-group redundancy, aligned
+  rule numbering.
+
+### Stress Test and Gap Closure (0.0.21 – 0.0.29)
+
+Identified and closed the enforcement gaps; the standard moved from structurally
+sound to operationally complete. *(Untagged.)*
+
+- **0.0.21** — Boundary stress test. Across eight attack surfaces and seven
+  scenarios, the test exposed **five gap areas**: audit record granularity,
+  governing-entity authentication, actor identity portability, the subprocessor
+  boundary, and revocation enforcement timing. *(Analysis document in
+  `proposals/0.0.21/`; undated.)*
+- **0.0.22** — Primary operational data clarification: closed the incomplete-export
+  gap (OWN-9, OWN-10). *(commit `e9e6d99`)*
+- **0.0.23** — Service provider boundary: defined SVC-8, SVC-9; closed the
+  subprocessor classification gap. *(commit `3d4b361`)*
+- **0.0.24** — Protocol normativity alignment: tightened protocol incorporation
+  scope; added PROT-1 through PROT-5. *(commit `0e34d08`)*
+- **0.0.25** — Actor identity portability: added ACTOR-1 through ACTOR-6.
+  *(commit `6681520`)*
+- **0.0.26** — Governing entity authenticity: added GEA-1 through GEA-6.
+  *(commit `462f7fb`)*
+- **0.0.27** — Audit resolution requirements: added AUD-1 through AUD-6.
+  *(commit `dc5d86c`)*
+- **0.0.28** — Delegation chain lifetime integrity: added DCL-1 through DCL-6.
+  *(commit `f60afa9`)*
+- **0.0.29** — Revocation enforcement timing: closed the cached-authorization-window
+  gap; added REV-1 through REV-6; made deferred revocation a non-conformance
+  condition. *(commit `f1eb992`)*
+
+**Result after 0.0.29:** all governance layers complete — 115 rules in 19 groups, 25
+non-conformance conditions — and the five gap areas from the 0.0.21 stress test
+resolved. Ready for the first Committee Vote.
+
+---
+
+## Understanding the Version Scheme
+
+LEBOSS uses semantic versioning `X.Y.Z` with LEBOSS-specific meaning:
+
+| Position | Label | Meaning | Examples |
+|----------|-------|---------|----------|
+| **X** (leftmost) | Published | Ratified by members; immutable canonical standard | 1.0.0 |
+| **Y** (middle) | Committee Vote | Accepted by committee; open for member ratification; 14-day minimum vote period | 0.1.0 |
+| **Z** (rightmost) | Draft | Working draft in active development; contributions welcome | 0.0.1, 0.0.29 |
+
+**Current state:** v0.1.0-rc / 0.0.29 — a Draft that is release-candidate-quality for
+the first Committee Vote.
+
+**What this means for implementers:**
+
+1. **Until v1.0.0, expect change.** All `0.x.x` versions are drafts; rules,
+   terminology, and protocol requirements may be revised.
+2. **v0.1.0 will be the first Committee Vote.** Once voted on it becomes more stable,
+   with a 14-day ratification period. The committee must be appointed before that vote
+   can be called.
+3. **v1.0.0 is immutable.** Once published, it cannot be modified; future changes
+   require a new version.
+4. **You can implement against 0.0.29 today.** Conformance is self-declared; you may
+   claim LEBOSS-aligned (structural) or LEBOSS-compliant (every MUST in
+   [`standards/conformance.md`](standards/conformance.md)). There is no breaking-change
+   guarantee until v1.0.0.
+
+---
+
+## How This Differs From RELEASES.md
+
+- [`CHANGELOG.md`](CHANGELOG.md) (this file) — the concise, scannable log of what
+  changed, version by version.
+- [`RELEASES.md`](RELEASES.md) — the full versioning policy, the governance workflow,
+  and the per-proposal history with links.
+
+For governance process details, see [`CONTRIBUTING.md`](CONTRIBUTING.md) and the
+[`charter`](charter/mission.md).

--- a/README.md
+++ b/README.md
@@ -2,53 +2,50 @@
 
 **Local Entrepreneur Business Operating System Standards**
 
-**Updated Through:** proposal/0.0.29
-
-[![Version](https://img.shields.io/badge/version-pre--v0.1.0-blue)](STATUS.md)
-[![Status](https://img.shields.io/badge/status-draft-orange)](STATUS.md)
+[![Version](https://img.shields.io/badge/version-v0.1.0--rc-blue)](STATUS.md)
+[![Status](https://img.shields.io/badge/status-release%20candidate-yellow)](STATUS.md)
+[![License: CC BY 4.0](https://img.shields.io/badge/license-CC%20BY%204.0-lightgrey)](LICENSE)
 [![Type](https://img.shields.io/badge/type-open%20standard-purple)](standards/leboss-standard.md)
-[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Spec](https://img.shields.io/badge/spec-115%20rules%20%2F%2019%20groups-informational)](standards/leboss-normative-rules.md)
+[![Portal](https://img.shields.io/badge/portal-live-brightgreen)](https://leboss.status26.com/)
 
-> An open governance standard defining ownership, access control, delegation, enforcement, audit, portability, identity, and revocation requirements for local business data systems.
+> **An open governance standard that puts local business data ownership back in the hands of the business.**
 
-See [STATUS.md](STATUS.md) for current specification status and release information.
+**LEBOSS is an open governance standard and a published presentation portal — not an app, SDK, or package you install.** It defines ownership, access control, delegation, enforcement, audit, portability, identity, and revocation for local business data systems. You read the spec, run the decks, or implement against it.
 
 ---
 
 ## The Problem
 
-Local businesses run on software. CRM, scheduling, billing, marketing, point-of-sale. Each system holds a piece of the business's operational data. In most cases, the **platform controls the data** — not the business.
+Local businesses run on software — CRM, scheduling, billing, marketing, point-of-sale. Each system holds a piece of the business's operational data. In most cases, the **platform controls the data, not the business**.
 
-- Switching vendors means losing history
-- Integrations acquire access without declared scope
-- No audit trail the business can inspect
-- Portability is a feature, not a right
+- Switching vendors means losing history.
+- Integrations acquire access without declared scope.
+- There is no audit trail the business can inspect.
+- Portability is a feature the vendor offers, not a right the owner holds.
 
-LEBOSS treats this as a **structural problem** with a structural solution: define ownership architecturally, not contractually.
+LEBOSS treats this as a **structural problem with a structural solution**: define ownership **architecturally, not contractually**. The owner of a business owns its data — and that ownership should be a property of the system's design, not a clause to be read in a contract after something has already gone wrong.
 
 ---
 
-## What LEBOSS Does
+## The Reference Model
 
-LEBOSS defines:
-
-- **A reference model** — six hierarchical elements that describe who owns what in a local business software system
-- **Governance objects** — the primitives (Access Grants, Audit Records, Integration Descriptors, Resources) that make data ownership enforceable
-- **Operational protocols** — normative rules for how those objects behave across their lifecycle
-- **A conformance definition** — the minimum requirements for claiming LEBOSS compatibility
+LEBOSS describes any local-business data system as six hierarchical elements. The **Universe** (Governing Entity) is the root owner of all data; every other element operates under explicit, scoped, revocable authorization, and every governed operation produces an Audit Record.
 
 ```mermaid
 flowchart LR
-    U(("0 · Universe"))
-    G(("1 · Galaxy"))
-    S(("2 · Star"))
-    P(("3 · Planet"))
-    M(("4 · Moon"))
-    T(("5 · Satellite"))
+    U(("0 · Universe\nGoverning Entity"))
+    G(("1 · Galaxy\nBrand / Business Line"))
+    S(("2 · Star\nCustomer Interface"))
+    P(("3 · Planet\nBackend Service"))
+    M(("4 · Moon\nInternal Capability\ncompany-owned"))
+    T(("5 · Satellite\nExternal Integration\nthird-party"))
 
-    U --> G --> S <--> P
-    P --> M
-    P --> T
+    U --> G
+    G --> S
+    S <--> P
+    P --- M
+    P --- T
 
     style U fill:#3b4fc8,color:#fff,stroke:none
     style G fill:#7c3aed,color:#fff,stroke:none
@@ -60,120 +57,224 @@ flowchart LR
 
 | Element | Role |
 |---------|------|
-| **0 · Universe** | Governing Entity — root owner of all data |
-| **1 · Galaxy** | Brand or business line |
-| **2 · Star** | Customer-facing interface |
-| **3 · Planet** | Backend service — holds primary operational data |
-| **4 · Moon** | Company-owned internal capability |
-| **5 · Satellite** | Third-party integration |
+| **0 · Universe** | Governing Entity — the person, family, or legal entity that owns all data |
+| **1 · Galaxy** | A brand or business line owned by the Universe |
+| **2 · Star** | Customer-facing interface (website, app, booking portal); cannot function without a Planet |
+| **3 · Planet** | Backend service that powers a Star; holds primary operational data |
+| **4 · Moon** | A *natural* satellite — a company-owned, company-operated internal capability |
+| **5 · Satellite** | An *artificial* satellite — a third-party integration; the greatest sovereignty risk, so it must be explicitly authorized and audited |
 
-The **Governing Entity** (Universe) owns all data. Every other element operates under explicit, scoped, revocable authorization. All governed operations produce Audit Records. The complete environment is always exportable by the Governing Entity.
+Star and Planet depend on each other bidirectionally: without a Planet to support it a Star cannot function, and without a Star a Planet serves no one. Moons and Satellites are *associated with* the Planet layer — they are capabilities and connections, not children in the ownership tree.
+
+<details>
+<summary>Plain-text version of the reference model</summary>
+
+```
+LEBOSS Reference Model
+───────────────────────────────────────────────────────
+
+  ┌─────────────────┐
+  │   0 · Universe  │   Root owner (person / family / legal entity)
+  │ Governing Entity│
+  └────────┬────────┘
+           │ owns
+  ┌────────▼────────┐
+  │   1 · Galaxy    │   Brand or business line
+  └────────┬────────┘
+           │ contains
+  ┌────────▼────────┐       ┌─────────────────────┐
+  │   2 · Star      │◄─────►│   3 · Planet         │
+  │ Customer        │       │ Backend Service      │
+  │ Interface       │       │ (holds primary data) │
+  └─────────────────┘       └──────────┬───────────┘
+                                       │
+                          ┌────────────┴────────────┐
+                          │                         │
+                 ┌────────▼────────┐       ┌────────▼────────┐
+                 │   4 · Moon      │       │  5 · Satellite  │
+                 │ Internal        │       │ External        │
+                 │ Capability      │       │ Integration     │
+                 │ [company-owned] │       │ [third-party]   │
+                 └─────────────────┘       └─────────────────┘
+
+  Moon:      natural satellite — company owned, company operated
+  Satellite: artificial satellite — third-party, outside direct control
+```
+
+</details>
+
+> See the interactive version in the Architecture deck at **[leboss.status26.com/architecture/](https://leboss.status26.com/architecture/)**.
 
 ---
 
-## Five Foundation Principles
+## What You Get
 
-| # | Principle | Meaning |
-|---|-----------|---------|
-| 1 | **Clarity** | Every element has a defined role and ownership boundary |
-| 2 | **Modularity** | Capabilities are interchangeable — replacing one does not cascade |
-| 3 | **Security** | Entity-separated data, least-privilege access, auditable operations |
-| 4 | **Legacy & Continuity** | Systems survive ownership transitions and vendor changes |
-| 5 | **Extensibility** | New capabilities attach without disrupting existing structure |
-
----
-
-## Specification
-
-| Document | Content |
-|----------|---------|
-| [standards/leboss-standard.md](standards/leboss-standard.md) | Base standard — reference model, data ownership doctrine, service provider obligations, conformance |
-| [standards/conformance.md](standards/conformance.md) | Conformance definition — minimum requirements for LEBOSS-compliant implementations |
-| [standards/leboss-normative-rules.md](standards/leboss-normative-rules.md) | Flat rule register — 115 normative rules across 19 rule groups |
-| [standards/leboss-resource-model.md](standards/leboss-resource-model.md) | Resource Model |
-| [standards/leboss-access-grant-protocol.md](standards/leboss-access-grant-protocol.md) | Access Grant Protocol |
-| [standards/leboss-integration-protocol.md](standards/leboss-integration-protocol.md) | Integration Descriptor Protocol |
-| [standards/leboss-audit-protocol.md](standards/leboss-audit-protocol.md) | Audit Record Collection Protocol |
-| [standards/leboss-data-portability-protocol.md](standards/leboss-data-portability-protocol.md) | Data Portability Protocol |
-| [standards/objects/access-grant.md](standards/objects/access-grant.md) | Access Grant object definition |
-| [standards/objects/integration-descriptor.md](standards/objects/integration-descriptor.md) | Integration Descriptor object definition |
-| [standards/objects/audit-record.md](standards/objects/audit-record.md) | Audit Record object definition |
+- **115 normative rules across 19 rule groups** — each coded `LEBOSS-{GROUP}-{n}` and traceable to its source section in the standard.
+- **A single ownership vocabulary** — the six-element reference model, defined once and referenced everywhere without drift.
+- **Owner-first data sovereignty** made architecturally enforceable, not contractual: the Governing Entity owns all data; everything else operates under scoped, revocable authorization.
+- **Audit as the system of record** — the audit corpus, not internal state, is the canonical truth.
+- **Checkable conformance** — 25 named non-conformance conditions, each mapped to specific rule IDs, plus two clear tiers.
+- **Open governance machinery** — proposal lifecycle, committee roles, conflict-of-interest policy, and PR template, all written.
 
 ---
 
-## Repository Structure
+## Getting Started
 
-| Directory | Purpose |
-|-----------|---------|
-| [`standards/`](standards/) | Normative specification — all MUST/SHOULD/MAY requirements |
-| [`glossary/`](glossary/) | Canonical terminology definitions |
+There is no package to install. Pick the path that fits your role.
+
+### 1 · Read the standard
+
+The authoritative artifact is Markdown. A good order:
+
+1. **[charter/mission.md](charter/mission.md)** — why LEBOSS exists.
+2. **[standards/leboss-standard.md](standards/leboss-standard.md)** — the base standard: scope, core concepts, the §5 reference model, ownership doctrine, service-provider obligations, conformance.
+3. **[standards/leboss-normative-rules.md](standards/leboss-normative-rules.md)** — the flat 115-rule register; your implementer checklist.
+4. **[standards/conformance.md](standards/conformance.md)** — the two conformance tiers and the 25 non-conformance conditions.
+5. **[glossary/terms.md](glossary/terms.md)** — keep it open while you read.
+
+New to the model? Start with [docs/explanation/why-the-orbital-model.md](docs/explanation/why-the-orbital-model.md), then walk through [docs/tutorials/model-your-first-business.md](docs/tutorials/model-your-first-business.md).
+
+### 2 · Run the presentation decks locally
+
+The three decks (Overview, Architecture, Governance) are deployed live at [leboss.status26.com](https://leboss.status26.com/). To run them yourself you need **Node.js 22** (pinned in `.nvmrc` and `package.json`):
+
+```bash
+cd presentations/slidev
+npm install
+npm run dev               # Overview deck
+npm run dev:architecture  # Architecture deck
+npm run dev:governance    # Governance deck
+```
+
+Each deck opens on its own port (Slidev prints the URL). To build all three exactly as deployed:
+
+```bash
+npm run build:all         # builds all three decks + copies _redirects into dist/
+```
+
+### 3 · Implement against the spec
+
+LEBOSS defines governance, not implementation. **Database, language, API style, runtime, and infrastructure are all your choice** — any stack works as long as the governance rules hold. Then declare one of two conformance tiers:
+
+- **LEBOSS-aligned** — your system preserves the six-element hierarchy, ownership boundaries, and dependency/access relationships from the reference model.
+- **LEBOSS-compliant** — your system satisfies *every* MUST-level requirement in [standards/conformance.md](standards/conformance.md), with none of the 25 non-conformance conditions true of it.
+
+Conformance is **self-declared**; there is no third-party certification program in this version. See [docs/how-to/check-conformance.md](docs/how-to/check-conformance.md) and [docs/how-to/map-a-satellite-conformantly.md](docs/how-to/map-a-satellite-conformantly.md), and the exact normative breakdown in [docs/reference/normative-structure.md](docs/reference/normative-structure.md). When you ship something, register it by PR to [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md) (currently empty — you would be the first).
+
+---
+
+## Why This — and When You Don't Need It
+
+LEBOSS makes data ownership **architectural and conformance-checkable** — not contractual, not jurisdictional, not ad-hoc. It gives a local business owner one model of the entire data footprint, three governance objects the *owner* holds (Access Grant, Integration Descriptor, Audit Record), and 115 traceable rules with 25 named non-conformance conditions. None of the common alternatives do all of that:
+
+- **Vendor terms of service** work today, but they govern what the *vendor* will do — not what you own architecturally. Portability is a feature that can be deprecated.
+- **Ad-hoc per-vendor data agreements** can be highly protective, but they don't scale across a multi-vendor stack and aren't checkable.
+- **Data-protection law (GDPR, CCPA)** has real legal force — but it governs the business-to-regulator relationship and your customers' rights, not how your own systems should be structured. LEBOSS is complementary, not a substitute.
+- **Data-portability efforts** are great for a concrete migration, but they answer "can I get my data out of X?" rather than "what governs ownership across my whole stack?"
+
+**You probably don't need LEBOSS if** you run a single isolated system with no integrations; your concern is regulatory compliance (talk to counsel and follow the law); you have a one-time migration to do (you need an export, not an architecture); you have no continuity or ownership-transfer concern; or you need something to run **today** — LEBOSS is a release candidate with zero implementations.
+
+For the full positioning, see [docs/explanation/why-the-orbital-model.md](docs/explanation/why-the-orbital-model.md) and [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md).
+
+---
+
+## Governance Lifecycle
+
+Every change to the standard moves through four stages. The version number encodes the stage: Draft increments the rightmost digit (Z), Committee Vote increments the middle (Y), and Published increments the leftmost (X).
+
+```mermaid
+flowchart LR
+    A["Proposal\n(PR opened)"]
+    B["Draft\n(≥14 days)"]
+    C["Committee Vote\n(≥14 days)"]
+    D["Published\nCanonical Standard"]
+
+    A -->|"accepted for\ncommittee review"| B
+    B -->|"committee\napproves"| C
+    C -->|"member\nratification"| D
+
+    style A fill:#64748b,color:#fff,stroke:none
+    style B fill:#3b4fc8,color:#fff,stroke:none
+    style C fill:#7c3aed,color:#fff,stroke:none
+    style D fill:#059669,color:#fff,stroke:none
+```
+
+LEBOSS is currently at **v0.1.0-rc** (proposal 0.0.29) — a structurally complete release candidate for the **first** Committee Vote. The next milestone, **v0.1.0**, opens that vote.
+
+---
+
+## Trust & Maturity
+
+This is an open-standards project early in its life. Both sides of that are stated plainly.
+
+**Real and verifiable:**
+
+- **CC BY 4.0 license** present at the repo root.
+- **A live, deployed portal** on Netlify, with a deploy preview generated for every PR and a committed lockfile for reproducible builds.
+- **A 29-proposal change history** (`0.0.1 → 0.0.29`), each directory preserved as a permanent record.
+- **115 traceable normative rules** and 25 non-conformance conditions, with version numbers consistent across every document.
+- **A fully written governance process** — proposal lifecycle, committee roles, PR template, conflict-of-interest policy.
+
+**Honest gaps (do not read past these):**
+
+- **No implementations yet** — `IMPLEMENTATIONS.md` is empty.
+- **Committee not appointed** — the Maintainer is "to be appointed" and member seats are open for nomination, so the first Committee Vote cannot be called yet.
+- **v0.1.0 has not been voted or ratified** — and conformance is self-declared; there is no certification body or third-party audit program.
+- **No CI / no automated build verification** — there is no `.github/` directory; build correctness is only checked when Netlify deploys.
+- **Git tags stop at `v0.0.11`** — `v0.0.12`–`v0.0.29` are untagged, so intermediate proposals cannot be pinned by tag.
+- **Slidev is pinned to an older release** (`@slidev/cli` 0.49.29) with no dependency scanning.
+
+The responsible expectation: **safe to read, safe to design against, not yet a frozen reference.** Rules may change at any proposal cycle before the first Published standard (v1.0.0); annotate anything you reference as "per LEBOSS v0.1.0-rc — subject to change."
+
+---
+
+## Repository Map
+
+| Path | Purpose |
+|------|---------|
+| [`standards/`](standards/) | Normative specification — all MUST / MUST NOT / MAY requirements |
+| [`glossary/`](glossary/) | Canonical terminology |
 | [`governance/`](governance/) | Governance model — proposal lifecycle, committee roles |
 | [`proposals/`](proposals/) | Specification change history (0.0.1 → 0.0.29) |
-| [`presentations/`](presentations/) | Three-deck Slidev presentation portal |
+| [`presentations/`](presentations/) | Three-deck Slidev portal (deployed to leboss.status26.com) |
 | [`charter/`](charter/) | Mission and philosophical foundation |
+| [`docs/`](docs/) | Tutorials, how-to guides, reference, and explanation |
 
----
-
-## Quick Links
+**Key links:**
 
 | | |
 |--|--|
-| **Specification** | [standards/leboss-standard.md](standards/leboss-standard.md) |
+| **The standard** | [standards/leboss-standard.md](standards/leboss-standard.md) |
+| **Rule register** | [standards/leboss-normative-rules.md](standards/leboss-normative-rules.md) |
 | **Conformance** | [standards/conformance.md](standards/conformance.md) |
+| **Normative structure** | [docs/reference/normative-structure.md](docs/reference/normative-structure.md) |
 | **Glossary** | [glossary/terms.md](glossary/terms.md) |
+| **Philosophy** | [docs/PHILOSOPHY.md](docs/PHILOSOPHY.md) |
+| **Tutorials & guides** | [docs/](docs/) |
 | **Governance** | [governance/governance.md](governance/governance.md) |
-| **Proposals** | [proposals/](proposals/) |
+| **Changelog** | [CHANGELOG.md](CHANGELOG.md) |
+| **Contributing** | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| **License** | [LICENSE](LICENSE) |
 | **Status** | [STATUS.md](STATUS.md) |
-| **Presentations** | [leboss.status26.com](https://leboss.status26.com/) |
-| **Implementations** | [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md) |
-
----
-
-## Presentations
-
-The specification is published as a three-deck interactive presentation portal at **[leboss.status26.com](https://leboss.status26.com/)**.
-
-| Deck | Audience | URL |
-|------|----------|-----|
-| Overview | Business owners, evaluators | [leboss.status26.com](https://leboss.status26.com/) |
-| Architecture | Developers, architects | [leboss.status26.com/architecture/](https://leboss.status26.com/architecture/) |
-| Governance | Contributors, implementers | [leboss.status26.com/governance/](https://leboss.status26.com/governance/) |
-
----
-
-## Ecosystem
-
-See [IMPLEMENTATIONS.md](IMPLEMENTATIONS.md) for projects implementing the LEBOSS standard.
+| **Live portal** | [leboss.status26.com](https://leboss.status26.com/) |
 
 ---
 
 ## Contributing
 
-LEBOSS is an open standard. Contributions are welcome from developers, architects, business owners, and anyone with a stake in local business data sovereignty.
+LEBOSS is at a formative moment — the standard is structurally complete, but the committee is forming and no implementations are registered yet, so early contributions carry real weight. There are four ways in:
 
-**Specification changes** require a proposal in [`proposals/`](proposals/).
-**Editorial improvements** to documentation may be submitted directly as a pull request.
+1. **Open a proposal** — a PR against `master` that introduces or modifies content in `standards/`. Anyone may open one; this is how the standard reached 0.0.29. Branch `proposal/X.Y.Z` (e.g. `0.0.30`), add `proposals/X.Y.Z/proposal.md`, edit the spec, and open the PR.
+2. **Challenge a rule** — open an issue that names a gap, ambiguity, or contradiction. You don't need a fix to contribute substantively.
+3. **Improve the decks** — PRs to `presentations/slidev/` follow the same conventions and must keep `npm run build:all` passing.
+4. **Register an implementation** — when you build a LEBOSS-aligned or LEBOSS-compliant system, file a PR to `IMPLEMENTATIONS.md`.
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the full process — how to open a proposal, the lifecycle from Proposal → Draft → Committee Vote → Published, and how to nominate yourself for the committee.
+Proposals use a five-section PR template (Summary, Motivation, Specification Changes, Impact Assessment, Backward Compatibility) and may be returned if it's missing. All commits follow [Conventional Commits](https://www.conventionalcommits.org/). The committee is open for nomination — open an issue titled `Committee Nomination: [Your Name]` with your background and any conflicts of interest.
 
-Every pull request automatically generates a **Netlify preview** of the presentation system so reviewers can see changes live before merging.
-
----
-
-## Current Status
-
-The specification is at the **v0.1.0-rc** milestone — structurally complete and open for community review as a release candidate for the first Committee Vote. The standard covers the full governance layer across 115 normative rules and 19 rule groups. All boundary gaps identified in the 0.0.21 stress test have been resolved.
-
-**Foundation (0.0.1–0.0.12):** Initial doctrine, normative rule register, governance object model, five operational protocols, resource model, conformance requirements, and terminology stabilization.
-
-**Governance boundary and enforcement (0.0.13–0.0.20):** Specification and implementation boundary defined; enforcement responsibility, audit as system of record, portability format requirements, resource identity mapping, delegation constraints, conformance verification, and structural normalization.
-
-**Stress test and gap closure (0.0.21–0.0.29):** Boundary stress test identified enforcement gaps; primary operational data boundary (OWN-9–10), service provider boundary (SVC-8–9), protocol normativity alignment (PROT-1–5), actor identity portability (ACTOR-1–6), governing entity authenticity (GEA-1–6), audit resolution requirements (AUD-1–6), delegation chain lifetime integrity (DCL-1–6), and revocation enforcement timing (REV-1–6).
-
-Full proposal history is in [`proposals/`](proposals/) and in [STATUS.md](STATUS.md).
-
-The next milestone is **v0.1.0** — the first Committee Vote candidate.
+Full process: [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 
-*LEBOSS is an open standard. All content in this repository is available for adoption, implementation, critique, and contribution.*
+## License
+
+LEBOSS is licensed under the **Creative Commons Attribution 4.0 International (CC BY 4.0)** license — see [LICENSE](LICENSE). You may reproduce, distribute, and build on this specification, including for conforming implementations, with attribution. All content in this repository is available for adoption, implementation, critique, and contribution.

--- a/docs/PHILOSOPHY.md
+++ b/docs/PHILOSOPHY.md
@@ -1,0 +1,291 @@
+# The LEBOSS Philosophy
+
+**Status:** v0.1.0-rc
+**Updated Through:** proposal/0.0.29
+
+This document explains *why* LEBOSS exists and what it stands for. It is doctrine,
+not specification. Every principle stated here is tethered to the charter
+([`charter/mission.md`](../charter/mission.md)) and to a specific section of the
+standard ([`standards/leboss-standard.md`](../standards/leboss-standard.md)). It
+invents nothing new. Where a claim is an aspiration rather than a present fact, it
+is marked plainly as one.
+
+For the project overview and quickstart, see [`README.md`](../README.md). For the
+normative rules themselves, see
+[`standards/leboss-normative-rules.md`](../standards/leboss-normative-rules.md).
+
+---
+
+## The Problem LEBOSS Refuses to Accept
+
+When a local business adopts modern software, something easy to miss happens
+beneath the excitement of new capability: the data the business generates — its
+customers, its history, its revenue, its relationships — quietly moves into
+infrastructure owned by someone else. The business owner holds a login. They do
+not hold their data.
+
+This is not a flaw in any one product. It is a structural outcome of how the
+software industry built its business model. Data locked inside a vendor's platform
+raises the cost of leaving, and high switching costs are durable revenue. In that
+framing, low portability is a feature, not a bug.
+
+The standard names this directly: the current industry model concentrates data
+ownership inside provider infrastructure as a mechanism of market control
+(`standards/leboss-standard.md` §2).
+
+LEBOSS refuses to accept this as the natural or permanent state of things. It
+proposes that data ownership can be made real — not by hoping vendors behave
+better, not by adding a clause to a terms-of-service agreement, but by making
+ownership *architectural*, built into the structure of the system itself. That is
+the problem this project was written to solve.
+
+---
+
+## The Doctrine
+
+The charter ([`charter/mission.md`](../charter/mission.md)) states five beliefs.
+They are not aspirational decoration. Each corresponds to something concrete in the
+specification.
+
+**1. The owner of a business owns its data.** *(charter/mission.md, "What We
+Believe")*
+
+This is the foundational claim. The standard translates it into a normative
+requirement: primary operational data generated within a LEBOSS-compliant system is
+owned by the governing entity — the Universe — to which it belongs
+(`standards/leboss-standard.md` §6.1). Ownership is not an attitude a vendor is
+asked to hold. It is a property the system must structurally express, enforced
+through the ten Ownership (OWN) rules and underpinned by the Access Grant model.
+
+**2. This principle must be made technically enforceable, not merely contractually
+promised.** *(charter/mission.md, "What We Believe")*
+
+The standard's §3.5 — "Ownership Must Be Technically Enforceable" — states this
+without equivocation: good intentions are insufficient, because a vendor who agrees
+in contract to treat business data responsibly while controlling all infrastructure
+can violate that agreement with little consequence. The architectural response is
+the Access Grant: no service provider may access primary operational data without
+an explicitly scoped, revocable grant issued by the governing entity
+(`standards/leboss-standard.md` §6.3).
+
+**3. The local business sector has been systematically underserved by an industry
+that built its revenue model on data extraction dressed as convenience.**
+*(charter/mission.md, "What We Believe")*
+
+The standard's problem statement names the mechanism: switching costs are high
+because migration costs are high because portability is low — by design
+(`standards/leboss-standard.md` §2). The response is the data portability
+requirement: a compliant system must be able to export all primary operational
+data, governance objects, and audit records in a documented, non-proprietary
+format, complete enough to reconstruct the governed environment in an independent
+system without reliance on the exporting system or its vendors
+(`standards/leboss-standard.md` §6.4).
+
+**4. Developers have the skill, the tools, and the ethical responsibility to build
+systems that honor the people who use them.** *(charter/mission.md, "What We
+Believe")*
+
+This principle lives in the standard's definition of a service provider: the
+governing criterion for provider obligations is the ability to access or control
+primary operational data — not the label applied to the relationship. An
+infrastructure provider is a service provider. A subcontractor with incidental
+access is a service provider. The standard requires disclosure, scoped access,
+audit records, and exit portability from all of them
+(`standards/leboss-standard.md` §7.0). It holds builders accountable by capability,
+not by self-description.
+
+**5. A standard — shared, open, freely adoptable — is the most durable mechanism
+for changing how an industry behaves.** *(charter/mission.md, "What We Believe")*
+
+The charter explains why a standard and not a product: LEBOSS is not a product, not
+a certification body, and not a trade association — it is a standard, published
+openly, maintained by a community, and freely available for adoption,
+implementation, critique, and improvement (`charter/mission.md`, "What LEBOSS Is").
+The license is CC BY 4.0 ([`LICENSE`](../LICENSE)). The governance workflow —
+Proposal → Draft → Committee Vote → Published — is fully specified and open to any
+contributor (see [`CONTRIBUTING.md`](../CONTRIBUTING.md)).
+
+---
+
+## The Five Foundation Principles
+
+The standard defines five foundation principles that a compliant system must embody
+(`standards/leboss-standard.md` §4). They are not value statements; they are
+normative design constraints, and each one closes a specific pathway by which
+ownership can be violated.
+
+**Clarity** closes the ambiguity pathway. Ambiguity about who owns a record, who
+authorized an integration, or which entity a dataset belongs to is the condition
+under which data appropriation occurs. Every part of the system must have a clearly
+defined role and place (`standards/leboss-standard.md` §4).
+
+**Modularity** closes the lock-in pathway. Components must be organized so that any
+individual provider or capability is replaceable without reconstructing the whole.
+Modularity is the structural guarantee of freedom of choice — the technical
+expression of the owner's right to leave (`standards/leboss-standard.md` §4).
+
+**Security** closes the unauthorized-access pathway. Data must be separated by
+business entity, access must follow least privilege, and all data operations must
+be auditable. Security in LEBOSS is a structural property of the architecture, not
+a bolt-on. This is the principle behind the five Access (ACC) rules, the five
+Security (SEC) rules, and the audit-record system (the four Audit-as-System-of-Record,
+REC, rules) (`standards/leboss-standard.md` §4).
+
+**Legacy and Continuity** closes the succession pathway. Data must remain accessible
+and portable through ownership transitions. A system that binds data to a specific
+person, role, or service agreement in a way that makes it inaccessible when that
+relationship ends has effectively expropriated it. This principle is embodied in the
+four Continuity (CONT) rules and the portability requirements of §6.4
+(`standards/leboss-standard.md` §4).
+
+**Extensibility** closes the entrenchment pathway. A system in which adding a new
+capability requires entangling it with everything else makes each new addition a new
+dependency, and each new dependency a new switching cost
+(`standards/leboss-standard.md` §4).
+
+Together, these five principles mean that if a system is structured correctly, data
+sovereignty does not depend on any vendor's good behavior. It is a property of the
+architecture.
+
+---
+
+## Why the Reference Model Embodies the Philosophy
+
+The six LEBOSS Elements — Universe, Galaxy, Star, Planet, Moon, Satellite — are not
+a naming scheme. They are a governance topology. The hierarchy expresses who owns
+what, and in what direction authority flows (`standards/leboss-standard.md` §5).
+
+```
+Universe → Galaxy → Star ↔ Planet → (Moon | Satellite)
+```
+
+The **Universe** is the root owner: the person, family, or registered legal entity
+that built the business. It is not a software construct but a legal and
+organizational reality that compliant systems must reflect. Every other element
+exists in relationship to the Universe, under its authority, subject to its
+governance decisions (`standards/leboss-standard.md` §5.2).
+
+The **Galaxy** is a distinct brand or business line within that Universe — its own
+data boundary and team structure, but owned by and accountable to the Universe.
+Multiple Galaxies under one Universe are explicitly supported, and data separation
+between them is a compliance requirement (`standards/leboss-standard.md` §5.2).
+
+The **Star** and **Planet** define the customer-facing and backend layers, with an
+explicit dependency rule: a backend (Planet) must serve at least one interface
+(Star), and an interface must be supported by at least one backend. Neither can
+exist without the other (`standards/leboss-standard.md` §5.4). This is not
+aesthetics — it is the rule that prevents backends from becoming orphaned data
+stores controlled by providers the business has nominally stopped using.
+
+The **Moon** is a natural satellite: a company-owned, company-operated internal
+capability within a Galaxy's data boundary, under the business's direct control. A
+Moon is what internal modularity looks like — separable, replaceable, entirely owned
+(`standards/leboss-standard.md` §5.2).
+
+The **Satellite** is where the philosophy comes under the most pressure. Satellites
+are artificial satellites: connections to third-party platforms — payment
+processors, marketing platforms, accounting software, business listing services —
+operated outside the business's direct control. The standard names them as the point
+of greatest data sovereignty risk (`standards/leboss-standard.md` §5.2). The response
+is not to prohibit them but to bound them: every Satellite requires explicit
+authorization, every data flow through a Satellite must be logged and auditable, and
+a Satellite must never become a path through which primary operational data leaves
+the business's control without authorization.
+
+The hierarchy is the philosophy made concrete. Ownership flows from the Universe
+outward. Authority is explicit and traceable at every level. The boundary where
+control ends — the Satellite — is the boundary the standard watches most carefully.
+
+---
+
+## The Right to Leave and the Right to Audit
+
+Two owner rights are load-bearing for everything above.
+
+**The right to leave** is a normative requirement, not a vendor option. The standard
+holds that a system that cannot return data to the owner is a system that has
+appropriated it (`standards/leboss-standard.md` §6.4). Export must be complete enough
+to reconstruct the governed environment elsewhere, in a documented, non-proprietary
+format, without dependence on the original vendor.
+
+**The right to audit** is built in: the audit corpus, not internal system state, is
+the canonical record (`standards/leboss-standard.md` §8). An owner who cannot inspect
+their own audit trail does not own their system in any meaningful sense. LEBOSS
+treats irreconcilable state — a discrepancy between what the audit record says and
+what the system actually did — as itself a non-conformance condition.
+
+---
+
+## Why a Standard, Not a Product
+
+A product can be acquired, pivoted, or shut down. A standard published under CC BY
+4.0, maintained through a transparent proposal process, and carrying a documented
+change history of twenty-nine proposals cannot be unmade by any single actor. The
+durability is structural (`charter/mission.md`, "What We Believe").
+
+So is the neutrality. LEBOSS explicitly does not prescribe runtime environments, API
+designs, infrastructure choices, or software architectures (`charter/mission.md`,
+"What LEBOSS Is"; `standards/leboss-standard.md` §1). Any implementation stack can
+conform. No vendor is advantaged by the specification itself.
+
+---
+
+## Our Relationship to Other Movements
+
+The charter places LEBOSS in a lineage (`charter/mission.md`, "Our Relationship to
+Other Movements"). The free software movement established that the tool need not be
+owned by the company that distributes it. The open source movement established that
+open development produces more trustworthy software. LEBOSS applies a parallel
+insight to data: the data generated by doing work belongs to the person doing the
+work, not to the tool that facilitated it.
+
+This is not a claim for public data. It is a claim for private property —
+specifically, for the property rights of a local business owner over the digital
+record of their own operation.
+
+The AI era makes this more urgent, not less. When AI-powered services use a
+business's operational data to train models the vendor monetizes elsewhere, the
+business owner has supplied free input to a competitor's product. LEBOSS does not
+prohibit AI applications. Applying the standard's prohibition on secondary use, it
+requires that when AI systems use primary operational data they do so under explicit
+authorization, with disclosed purpose, and with the understanding that the owner's
+data is not a free input to a model the vendor will monetize elsewhere
+(`standards/leboss-standard.md` §7.6; `charter/mission.md`, "A Note on the AI Era").
+
+---
+
+## What Is Aspiration (Marked Clearly)
+
+The following are genuine aspirations of the project, not current facts. They belong
+in any honest statement of the doctrine, stated as aspiration:
+
+- **Community ratification.** The standard is a release candidate (v0.1.0-rc) for its
+  first Committee Vote. The committee is not yet appointed, and no vote has been
+  called.
+- **Adoption.** No implementations have been registered. The `IMPLEMENTATIONS.md`
+  table is empty.
+- **Formal certification.** Conformance is currently self-declared. No third-party
+  certification program exists in this version.
+- **Industry change.** The conviction that a shared standard is the most durable
+  mechanism for changing industry behavior is exactly that — a conviction, not a
+  demonstrated outcome.
+
+The conviction is legitimate. The traction is not yet there. Both are true at once.
+
+---
+
+## Where to Go Next
+
+- [`README.md`](../README.md) — project overview, quickstart, and positioning
+- [`standards/leboss-standard.md`](../standards/leboss-standard.md) — the
+  authoritative specification
+- [`standards/leboss-normative-rules.md`](../standards/leboss-normative-rules.md) —
+  the flat 115-rule register
+- [`charter/mission.md`](../charter/mission.md) — the charter this doctrine draws from
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — how to propose changes and join the
+  forming committee
+
+---
+
+*The LEBOSS Philosophy — open for community review and amendment through the standard
+Proposal process.*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,30 @@
+# LEBOSS Documentation
+
+These docs orient you to the LEBOSS standard. They do not replace it. Every
+normative requirement lives in [`standards/leboss-standard.md`](../standards/leboss-standard.md)
+and its incorporated protocol documents; the pages here help you find, apply,
+and understand that material.
+
+LEBOSS is an open governance standard — a Markdown specification plus a live
+presentation portal at <https://leboss.status26.com/> — not a library, SDK, or
+runtime. There is nothing to `npm install` to "use" LEBOSS. You read it, you
+align a system to it, or you implement against it.
+
+The documentation is organized in the four [Diátaxis](https://diataxis.fr/)
+modes, by what you are trying to do:
+
+| If you want to… | Go to | Mode |
+|---|---|---|
+| Learn the model by doing — map a real business onto the six elements | [Tutorial: Model your first business](tutorials/model-your-first-business.md) | Learning |
+| Evaluate a system for a LEBOSS-aligned or LEBOSS-compliant claim | [How-to: Check conformance](how-to/check-conformance.md) | Task |
+| Add a third-party integration (Satellite) without breaking conformance | [How-to: Map a Satellite](how-to/map-a-satellite-conformantly.md) | Task |
+| Look up rule groups, elements, tiers, or non-conformance conditions | [Reference: Normative structure](reference/normative-structure.md) | Information |
+| Understand *why* the model is built this way | [Explanation: Why the orbital model](explanation/why-the-orbital-model.md) | Understanding |
+
+For the philosophical foundation, see [`docs/PHILOSOPHY.md`](PHILOSOPHY.md) and
+[`charter/mission.md`](../charter/mission.md).
+
+These pages are written to a release candidate, **v0.1.0-rc**. The committee is
+not yet appointed, there are no registered implementations yet, and conformance
+is self-declared. Where that maturity matters to what you are doing, the page
+says so.

--- a/docs/explanation/why-the-orbital-model.md
+++ b/docs/explanation/why-the-orbital-model.md
@@ -1,0 +1,262 @@
+# Why an Orbital Reference Model — and Why Ownership Must Be Architectural
+
+This page explains the reasoning behind the LEBOSS Reference Model: why there is
+a model at all, why it is a hierarchy, why these six elements, and why ownership
+is treated as a structural matter rather than a contractual one. It is for
+readers who already understand *what* LEBOSS does and want to understand *why* it
+is shaped the way it is.
+
+It does not restate the rules — it references them by code — and it defers the
+deeper philosophical argument (that the owner of a business owns its data) to
+[`docs/PHILOSOPHY.md`](../PHILOSOPHY.md) and
+[`charter/mission.md`](../../charter/mission.md).
+
+---
+
+## The problem that required a model at all
+
+LEBOSS could have been written as a list of rules without a model. "Service
+providers must not retain data. Access must be scoped. Integrations must be
+logged." Each rule would be correct and independently defensible.
+
+The trouble with that approach is the same trouble that makes local-business
+data governance hard in the first place: the relationship between the parts is
+invisible. A rule that says "access must be scoped" does not tell you *scoped to
+what*, *scoped by whom*, or *scoped within which boundary*. Without a vocabulary
+for the entities involved and the relationships between them, every rule is
+interpretable by whoever finds it most convenient. A service provider can agree
+to "scope access" without anyone agreeing on what the scope covers. An auditor
+can confirm that access grants exist without being able to judge whether they
+are consistent with the ownership structure of the business.
+
+The Reference Model exists so that the rules attach to something. It gives every
+rule a subject and a boundary.
+*(See [`standards/leboss-standard.md` §5](../../standards/leboss-standard.md).)*
+
+---
+
+## Why a hierarchy, not a flat list of components
+
+The Reference Model defines a strict hierarchy:
+`Universe → Galaxy → Star ↔ Planet → (Moon | Satellite)`. Not a network, not a
+set of cooperating peers — a tree rooted at the governing entity.
+
+This is a deliberate choice with a specific consequence: ownership is
+unambiguous at every point in the tree.
+
+In a flat arrangement — where an owner, several brands, multiple websites, and a
+set of integrations all sit at the same level — any claim of ownership requires a
+declaration. Someone has to *say* who owns what, and that declaration can change
+or be disputed. In a hierarchy rooted at the Universe, ownership is positional.
+Every element below the Universe is owned by, or operates within the authorized
+boundary of, the element above it. There is no separate "who owns this?"
+question — the answer is encoded in the position.
+*(See [`standards/leboss-standard.md` §5.2–§5.3](../../standards/leboss-standard.md).)*
+
+The hierarchy is also what makes the data-boundary rules enforceable. Because
+each Galaxy has its own distinct boundary, the rule "data belonging to one brand
+entity must not be reachable from another without an explicit cross-entity
+access grant" is checkable: you know which boundary you are crossing because the
+hierarchy defines it (LEBOSS-ARCH-3).
+
+---
+
+## Why six elements, and why these six
+
+The six elements capture the meaningful ownership and responsibility
+distinctions in a local-business digital ecosystem — no more, no fewer.
+
+Consider what has to be distinguished:
+
+- **Ultimate authority** (Universe) from **operational control of one brand**
+  (Galaxy). One person can own several brands; their authority over each is not
+  diminished by the others, but the operational data for each should be cleanly
+  bounded.
+- **The interface the world sees** (Star) from **the engine behind it** (Planet).
+  This separation is what makes a provider replaceable. If a Star and its Planet
+  were fused into one inseparable unit, the business could not change the backend
+  without losing the customer experience, nor change the frontend without
+  rebuilding the backend. Separating them structurally enforces modularity.
+  *(See Principle 2, Modularity, in
+  [`standards/leboss-standard.md` §4](../../standards/leboss-standard.md).)*
+- **Internal capabilities the business owns** (Moon) from **external connections
+  the business authorizes** (Satellite). This is the sovereignty boundary. A
+  Moon sits inside the business's control; a Satellite sits outside it. The
+  distinction decides what governance applies: a Moon needs no explicit
+  cross-boundary authorization because the business is using its own resource; a
+  Satellite needs explicit authorization precisely because data is leaving the
+  business's operational boundary (LEBOSS-ACC-5).
+
+Six elements because there are six meaningful ownership and governance
+distinctions — not because an orbital metaphor needs six bodies.
+
+---
+
+## Why the spatial metaphor, and its limits
+
+The names Universe, Galaxy, Star, Planet, Moon, and Satellite are explicitly
+called out as illustrative, not prescriptive.
+*(See [`standards/leboss-standard.md` §5.1](../../standards/leboss-standard.md).)*
+
+The metaphor earns its place because it communicates hierarchy and scale
+intuitively. A Universe contains galaxies; galaxies contain systems; systems
+have natural and artificial satellites. A reader meets the model and immediately
+has a spatial intuition for the containment relationships.
+
+Its limits matter just as much. The metaphor suggests physical laws — orbits,
+gravity, fixed motion — and the model implies none of them. A Moon does not
+"orbit" a Planet in any functional sense; it is an internal capability that
+operates within a boundary, not a body bound by gravity.
+
+More importantly, implementations are free to use any internal names. A system
+that calls its governing entity "Owner," its brand entity "Workspace," and its
+external integrations "Connectors" can claim LEBOSS-aligned, provided the
+underlying ownership relationships, data boundaries, and dependency rules are
+preserved. Use the spatial names when talking *about* the model; use whatever
+names make sense inside your implementation.
+
+---
+
+## Why ownership must be architectural, not contractual
+
+This is the core claim of LEBOSS, and it is worth stating precisely.
+
+A *contractual* ownership claim says: we agree, in a document, that the business
+owner owns their data; the service provider acknowledges it; both parties sign.
+The weakness is not that contracts are unenforceable — often they are
+enforceable. The weakness is that a contract does not change who has the
+*operational capacity* to access, modify, delete, or withhold the data. A
+provider who has agreed on paper that the data belongs to the client, and who
+also controls all the infrastructure, has agreed to something they retain the
+technical ability to violate.
+
+An *architectural* ownership claim says: the system is structured so that the
+governing entity holds authority by position in the hierarchy, not by agreement.
+Service providers operate within explicitly scoped grants. Those grants are
+revocable, and revocation takes effect at the point of enforcement — not at some
+agreed future moment, not after a transition period. Data portability is a
+function of the system, available at any time, not a feature a provider can gate
+behind a premium tier or a termination procedure.
+
+The difference is enforcement at the architecture level rather than the contract
+level. LEBOSS is explicit that policy declarations and stated intent do not
+constitute enforcement.
+*(See [`standards/leboss-standard.md` §8.6](../../standards/leboss-standard.md)
+and [`standards/conformance.md` §3.7](../../standards/conformance.md);
+LEBOSS-ENF-1.)*
+
+This is also why the standard insists that the governing entity's authority be
+independent of any platform. A governing entity whose identity is just a platform
+account — one a provider controls, can deactivate, and can reassign — is not
+really the governing entity. The platform is.
+*(See [`standards/leboss-standard.md` §22](../../standards/leboss-standard.md);
+LEBOSS-GEA-1 through GEA-6.)*
+
+---
+
+## Why the Satellite carries the most risk
+
+The standard names the Satellite as the element of greatest data-sovereignty
+risk.
+*(See [`standards/leboss-standard.md` §5.2, Element 5](../../standards/leboss-standard.md).)*
+
+This is not incidental. In practice, local-business data leaves the business's
+control most routinely through integrations — the Google Business Profile
+connection, the payment processor, the CRM sync, the email-marketing platform.
+Each is an authorized data exit. The question is whether the authorization is
+explicit, scoped, audited, and revocable — or whether data simply flows because
+a developer wired up an integration and no one tracked the scope or the trail.
+
+The Satellite rules (LEBOSS-ACC-5, LEBOSS-ARCH-9 through ARCH-11) require that no
+Satellite receives data without explicit authorization at the brand or governing
+entity level, and that all flows through Satellites are logged. The Integration
+Descriptor Protocol (LEBOSS-IDP-1 through IDP-26) makes this operationally
+specific: registration before data flows, authorization before activation,
+cascade suspension on grant revocation, and full audit coverage of every
+lifecycle event.
+
+The reason for this rigor is that integrations are how the current industry
+model accumulates leverage. Platforms gather data by being integrated into every
+operational system a business touches. Any single integration may be legitimate
+and useful; the aggregate effect is that the business's operational data ends up
+distributed across a set of third-party systems, each holding a piece, with no
+way for the business to see the whole picture, revoke access efficiently, or
+recover what has been shared. LEBOSS treats each Satellite as a boundary to be
+explicitly governed, not assumed.
+
+---
+
+## Why the Audit Record is foundational, not supplementary
+
+Most systems treat audit logs as a compliance artifact — generated to satisfy a
+requirement, read rarely, stored apart from the "real" system state.
+
+LEBOSS is built on the opposite premise: the Audit Record corpus is the
+authoritative account of what has happened in the governed environment. System
+state must be reconcilable with the audit record. If the system says a grant is
+active but the audit record shows it was revoked, the audit record governs — and
+the irreconcilable state is itself a non-conformance condition.
+*(See [`standards/leboss-standard.md` §8.7](../../standards/leboss-standard.md);
+LEBOSS-REC-2; [`standards/conformance.md` §4 item 9](../../standards/conformance.md).)*
+
+This changes what an audit record must contain. If audit records are
+supplementary, they need only note that events occurred. If they are
+foundational, they must hold enough detail to reconstruct *what* occurred — which
+resources, under which grant, with what outcome, by which actor, in terms that
+remain interpretable outside the originating system. That is what the Audit
+Resolution rules require: a resolution floor for audit content, not merely an
+existence requirement.
+*(See [`standards/leboss-standard.md` §23](../../standards/leboss-standard.md);
+LEBOSS-AUD-1 through AUD-6.)*
+
+The implication for implementers is significant: you cannot design the system so
+that the audit log is *derived from* system state. The audit log must be able to
+*reconstruct* system state. The record is primary; the internal representation
+is secondary.
+
+---
+
+## What the model deliberately does not decide
+
+Understanding what LEBOSS leaves undefined is as important as understanding what
+it specifies. The standard deliberately does not prescribe:
+
+- runtime environment, programming language, or infrastructure platform,
+- API design, interface protocols, or serialization formats,
+- specific software-architecture patterns,
+- database technology.
+
+This is not an oversight; it is the point of the specification boundary. LEBOSS
+defines what must be *true* of a governed system, not how those truths are
+realized in code and infrastructure.
+*(See [`standards/leboss-standard.md` §1.2](../../standards/leboss-standard.md);
+LEBOSS-SPEC-1 through SPEC-4; and
+[`standards/conformance.md` §5](../../standards/conformance.md).)*
+
+Two systems built on entirely different stacks — one relational, one
+document-store; one REST, one event-driven — are equally conformant if both
+satisfy the governance requirements. Conformance is stack-independent by design.
+
+That matters for adoption. A standard that mandated a particular implementation
+technology would benefit the vendors who built to it and shut out everyone else.
+LEBOSS's freedom from implementation prescription is what makes it a standard
+rather than a framework.
+
+---
+
+## Further reading
+
+- **The philosophical foundation** — [`docs/PHILOSOPHY.md`](../PHILOSOPHY.md) and
+  [`charter/mission.md`](../../charter/mission.md): why the owner of a business
+  owns its data, and what that means for system design.
+- **The normative expression** —
+  [`standards/leboss-standard.md`](../../standards/leboss-standard.md): the full
+  specification, including the Reference Model in §5.
+- **The rule register** —
+  [`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md):
+  the 115 rules that give the model operational force.
+- **The conformance model** —
+  [`standards/conformance.md`](../../standards/conformance.md): what the model
+  requires in checkable form.
+- **Quick lookup** —
+  [Normative structure reference](../reference/normative-structure.md).

--- a/docs/how-to/check-conformance.md
+++ b/docs/how-to/check-conformance.md
@@ -1,0 +1,172 @@
+# How to Check Your System Against the LEBOSS Rules
+
+This guide gives you a repeatable procedure for evaluating whether a system
+qualifies for a LEBOSS conformance claim. It tells you which sections to check
+and in what order. It does not explain *why* each rule exists — for that, see
+[Why the orbital model](../explanation/why-the-orbital-model.md) and
+[`docs/PHILOSOPHY.md`](../PHILOSOPHY.md). It does not restate the requirements
+themselves — the authoritative text is in
+[`standards/conformance.md`](../../standards/conformance.md) and
+[`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md).
+
+**Prerequisites:** familiarity with the six elements (see the
+[tutorial](../tutorials/model-your-first-business.md) if you need it) and access
+to the conformance document and the rule register.
+
+> Conformance under v0.1.0-rc is **self-declared**. No formal third-party
+> certification program exists in this version.
+> *(See [`standards/conformance.md` §6](../../standards/conformance.md).)*
+
+---
+
+## Step 1 — Pick the tier you are evaluating for
+
+Decide this before you start. LEBOSS defines exactly two conformance tiers.
+*(See [`standards/conformance.md` §1.0](../../standards/conformance.md) and
+[`glossary/terms.md`](../../glossary/terms.md).)*
+
+- **LEBOSS-aligned** — the *structural* claim. The system preserves the
+  ownership hierarchy, data boundaries, dependency rules, and access-control
+  relationships of the Reference Model. Internal naming is irrelevant.
+- **LEBOSS-compliant** — the *normative* claim. The system satisfies every
+  MUST-level requirement in `standards/conformance.md` §3 and exhibits none of
+  the non-conformance conditions in §4. Every LEBOSS-compliant system is also
+  LEBOSS-aligned.
+
+The term **"LEBOSS-conformant" is not a defined conformance claim** and must not
+be used.
+*(See [`standards/conformance.md` §1.0](../../standards/conformance.md) and
+[`glossary/terms.md`](../../glossary/terms.md).)*
+
+If you only need to assert that your architecture is organized the LEBOSS way,
+aim for LEBOSS-aligned and run Step 2. If you intend to claim full behavioral
+conformance, you must clear Step 2, Step 3, *and* Step 4.
+
+---
+
+## Step 2 — LEBOSS-aligned: the structural checks
+
+Open [`standards/leboss-standard.md` §8.1–§8.4](../../standards/leboss-standard.md)
+and confirm each of the following holds.
+
+1. **Structural alignment (§8.1)** — the architecture reflects the ownership
+   hierarchy and data boundaries of §5. Each governed environment maps to
+   exactly one governing entity.
+2. **Brand-boundary enforcement (§8.1)** — data belonging to one brand entity
+   cannot reach another without an explicit cross-entity access grant.
+3. **Data-ownership alignment (§8.2)** — primary operational data is owned by
+   the governing entity, not by a service provider.
+4. **Service-provider alignment (§8.3)** — service providers operate under
+   explicit, scoped access grants.
+5. **Security alignment (§8.4)** — external integration boundaries are
+   explicitly authorized and audited.
+
+If all five hold, you may claim **LEBOSS-aligned**. Internal naming does not
+matter; the relationships do.
+*(See [`standards/leboss-standard.md` §5.4](../../standards/leboss-standard.md).)*
+
+---
+
+## Step 3 — LEBOSS-compliant: the minimum requirements
+
+Open [`standards/conformance.md` §3](../../standards/conformance.md) and work
+through each subsection in order. Each maps to a MUST in the standard.
+
+- **§3.1 Governing entity** — is there a uniquely identifiable root owner that
+  holds ownership over the system's operational resources?
+- **§3.2 Resource model** — does the system uniquely identify every governed
+  resource, enumerate the complete set per governing entity, and associate each
+  resource with exactly one governing entity? Are resources owned only by the
+  governing entity — never by service providers, integrations, or
+  infrastructure operators?
+- **§3.3 Access grants** — does every integration or actor require an explicit,
+  scoped access grant before operating on governed resources? Are operations
+  with no active grant structurally impossible?
+- **§3.4 Audit records** — is an audit record created for every operation
+  affecting governed resources, including timestamp, actor identity, affected
+  resource(s), and operation type? Are records protected from modification or
+  deletion by anyone other than the governing entity under documented retention
+  policy?
+- **§3.5 Data portability** — can the governing entity export all primary
+  operational data and the complete governance history at any time, without
+  service-provider assistance, in complete, relationship-preserving,
+  reconstructable, format-independent exports with a manifest?
+- **§3.6 Audit history access** — can the governing entity query audit history
+  independently, without service-provider cooperation?
+- **§3.7 Operational enforcement** — are requirements enforced in operation, not
+  merely documented in policy?
+- **§3.8 Cross-system identity** — do governed resources carry stable, portable
+  identity that survives export and import unaltered?
+- **§3.9 Delegation** — does the delegation model enforce scope limits, full
+  chain traceability to the root grant, and cascade revocation?
+- **§3.10 Conformance verification** — is the conformance claim supportable
+  through observable system behavior and audit records, verifiable by an
+  independent party without relying on the system's own assertions alone?
+
+Any item answered "no" or "partially" means the system does **not** yet qualify
+for the LEBOSS-compliant claim.
+
+---
+
+## Step 4 — Rule out the 25 non-conformance conditions
+
+A system that satisfies §3 **must still not** be described as LEBOSS-compliant
+if any of the 25 conditions in
+[`standards/conformance.md` §4](../../standards/conformance.md) is present. Scan
+the full list. The conditions most commonly triggered in early implementations
+are:
+
+- **#1 Unauthorized access** — an integration or actor can touch governed
+  resources without an active grant.
+- **#2 Audit bypass** — some operation is not logged, by design or
+  configuration.
+- **#4 Export restriction** — the governing entity needs service-provider
+  approval or a paid tier to export its own data.
+- **#8 Unenforced requirements** — conformance rests on documentation or policy
+  rather than operational enforcement.
+- **#25 Deferred revocation enforcement** — a revoked grant keeps authorizing
+  access because of caching or asynchronous state
+  (LEBOSS-REV-1, LEBOSS-REV-3, LEBOSS-REV-5).
+
+These five are starting points, not a shortcut. Read all 25 before declaring
+compliance. The [normative-structure reference](../reference/normative-structure.md)
+gives the full index of conditions with their governing rule IDs.
+
+---
+
+## Step 5 — Declare conformance
+
+Conformance is self-declared.
+*(See [`standards/conformance.md` §6](../../standards/conformance.md).)*
+
+To register an implementation, open
+[`IMPLEMENTATIONS.md`](../../IMPLEMENTATIONS.md) and add a row to the table:
+
+- the project name,
+- the LEBOSS version you target (for example, `v0.1.0`),
+- the conformance level (in development, LEBOSS-aligned, or LEBOSS-compliant),
+- a link or short description.
+
+Open a pull request against `master`. Once it is merged, the implementation is
+registered. The registry is currently empty — yours may be the first entry.
+
+Whatever you declare, the claim must be supportable through observable system
+behavior and audit records, not documentation alone
+(LEBOSS-VER-2, LEBOSS-VER-4, LEBOSS-VER-6).
+
+---
+
+## References
+
+- Conformance tiers, §3 requirements, §4 conditions —
+  [`standards/conformance.md`](../../standards/conformance.md)
+- The 115-rule register —
+  [`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md)
+- Structural alignment checks (§8.1–§8.4) —
+  [`standards/leboss-standard.md`](../../standards/leboss-standard.md)
+- Terminology, including tier definitions —
+  [`glossary/terms.md`](../../glossary/terms.md)
+- Quick lookup of rule groups and conditions —
+  [Normative structure reference](../reference/normative-structure.md)
+- Implementations registry —
+  [`IMPLEMENTATIONS.md`](../../IMPLEMENTATIONS.md)

--- a/docs/how-to/map-a-satellite-conformantly.md
+++ b/docs/how-to/map-a-satellite-conformantly.md
@@ -1,0 +1,161 @@
+# How to Map a Third-Party Integration (Satellite) to LEBOSS Conformance
+
+A Satellite is the element at greatest data-sovereignty risk in the LEBOSS
+Reference Model. Every connection to a third-party platform — a payment
+processor, a marketing tool, a review platform — is a Satellite. Under LEBOSS,
+no data may flow to a Satellite without explicit authorization, and every data
+operation through a Satellite must be logged.
+*(See [`standards/leboss-standard.md` §5.2, Element 5](../../standards/leboss-standard.md),
+and the access rule LEBOSS-ACC-5.)*
+
+This guide gives you the steps to add a Satellite to a LEBOSS system without
+triggering a non-conformance condition. It assumes you have already placed the
+integration as a Satellite — if not, work through the
+[tutorial](../tutorials/model-your-first-business.md) first.
+
+> The full object definitions and lifecycle state machine live in
+> [`standards/leboss-integration-protocol.md`](../../standards/leboss-integration-protocol.md)
+> (LEBOSS-IDP-1 through IDP-26) and
+> [`standards/objects/integration-descriptor.md`](../../standards/objects/integration-descriptor.md).
+> This guide points into them; it does not restate them.
+
+---
+
+## Step 1 — Create an Integration Descriptor before any data flows
+
+An Integration Descriptor must exist before any external integration receives
+data. Registration is **not** authorization — creating the descriptor does not
+permit data flow.
+*(See [`standards/leboss-standard.md` §13](../../standards/leboss-standard.md);
+LEBOSS-ACC-5.)*
+
+The descriptor moves through five lifecycle states:
+
+```
+registered → authorized → active → suspended → deactivated
+```
+
+At registration, capture:
+
+- the external platform being integrated,
+- the data categories that will flow,
+- the direction of flow (inbound, outbound, or bidirectional),
+- the business purpose.
+
+Your system must enforce that **no data flows** to or from the integration while
+its descriptor is in `registered` state.
+
+---
+
+## Step 2 — Obtain and link an explicit Access Grant
+
+The descriptor transitions to `authorized` only when a valid Access Grant,
+issued by the governing entity, is linked to it.
+*(See [`standards/leboss-standard.md` §13](../../standards/leboss-standard.md);
+LEBOSS-ACC-5.)*
+
+The Access Grant must specify:
+
+- the subject (the integration being granted access),
+- the scope (which resources and which operations are permitted),
+- the granting authority (the governing entity or its delegate).
+
+*(See [`standards/conformance.md` §3.3](../../standards/conformance.md);
+LEBOSS-ACC-1, LEBOSS-ACC-2.)*
+
+The governing entity — the Universe — must issue or authorize this grant. A
+service provider cannot self-grant access to primary operational data
+(LEBOSS-ACC-1). For the issuance and validation mechanics, see
+[`standards/leboss-access-grant-protocol.md`](../../standards/leboss-access-grant-protocol.md)
+(LEBOSS-AGP-1 through AGP-17).
+
+---
+
+## Step 3 — Validate each data operation before it executes
+
+Once the integration is `active`, every data operation through it must pass a
+five-step validation before execution.
+*(See [`standards/leboss-standard.md` §13](../../standards/leboss-standard.md).)*
+
+1. The Integration Descriptor exists and is in `active` state.
+2. A valid, linked Access Grant exists and has not expired.
+3. The Access Grant has not been revoked.
+4. The operation is within the grant's scope.
+5. The resource being operated on is covered by the grant.
+
+If any check fails, the operation must be denied — and the denial must itself be
+recorded as an Audit Record.
+
+---
+
+## Step 4 — Log every lifecycle event and data operation
+
+All data flows in and out through Satellites must be logged and auditable.
+*(See [`standards/leboss-standard.md` §5.2, Element 5](../../standards/leboss-standard.md);
+LEBOSS-ARCH-11.)*
+
+Every lifecycle event — registration, authorization, activation, each data
+operation, suspension, deactivation — must produce an Audit Record that includes
+the `integration_id` and, for data operations, the `grant_id`.
+*(See [`standards/leboss-standard.md` §13 and §14](../../standards/leboss-standard.md).)*
+
+Each Audit Record must include a timestamp, the actor identity, the resource(s)
+affected, and the operation type.
+*(See [`standards/conformance.md` §3.4](../../standards/conformance.md).)* The
+capture, correlation, retention (36-month minimum), and integrity requirements
+are specified in
+[`standards/leboss-audit-protocol.md`](../../standards/leboss-audit-protocol.md)
+(LEBOSS-ACP-1 through ACP-24).
+
+---
+
+## Step 5 — Implement the revocation, suspension, and deactivation cascade
+
+- If the linked Access Grant is **revoked**, the integration must be
+  **immediately suspended** — no separate suspension command is required.
+  Revocation cascades automatically.
+  *(See [`standards/leboss-standard.md` §13](../../standards/leboss-standard.md);
+  LEBOSS-REV-1.)*
+- **Suspension** is immediate and **reversible**: a new, valid grant can
+  reauthorize the integration.
+- **Deactivation** is immediate and **permanent**: a deactivated integration
+  cannot be reactivated. Reconnection requires a new descriptor and a new grant.
+
+The cascade — grant revocation triggering integration suspension — must itself
+produce its own Audit Records, linked by shared identifier references.
+*(See [`standards/leboss-standard.md` §14](../../standards/leboss-standard.md).)*
+
+---
+
+## Non-conformance conditions to watch for
+
+Before claiming conformance, verify the integration triggers none of these.
+*(See [`standards/conformance.md` §4](../../standards/conformance.md).)*
+
+- **#1 Unauthorized access** — data reaches the integration before the
+  descriptor is authorized and the grant is active.
+- **#2 Audit bypass** — any data operation through the integration is not logged.
+- **#20 Protocol-only compliance** — the register-level rule for ACC-5 is
+  satisfied but the behavioral requirements in the Integration Descriptor
+  Protocol (LEBOSS-IDP-1 through IDP-26) are not.
+- **#25 Deferred revocation enforcement** — a revoked grant keeps permitting
+  data flow because of cached, stale, or asynchronous state.
+
+---
+
+## References
+
+- Integration lifecycle in the base standard —
+  [`standards/leboss-standard.md` §5.2 (Element 5), §13, §14](../../standards/leboss-standard.md)
+- Integration Descriptor Protocol (LEBOSS-IDP-1 through IDP-26) —
+  [`standards/leboss-integration-protocol.md`](../../standards/leboss-integration-protocol.md)
+- Integration Descriptor object —
+  [`standards/objects/integration-descriptor.md`](../../standards/objects/integration-descriptor.md)
+- Access Grant Protocol (LEBOSS-AGP-1 through AGP-17) —
+  [`standards/leboss-access-grant-protocol.md`](../../standards/leboss-access-grant-protocol.md)
+- ACC and ARCH rule groups —
+  [`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md)
+- Conformance checks (§3.3) and conditions (§4 items 1, 2, 20, 25) —
+  [`standards/conformance.md`](../../standards/conformance.md)
+- Quick lookup of rule groups and conditions —
+  [Normative structure reference](../reference/normative-structure.md)

--- a/docs/reference/normative-structure.md
+++ b/docs/reference/normative-structure.md
@@ -1,0 +1,215 @@
+# LEBOSS Normative Structure — Quick Reference
+
+A lookup index for the normative structure of the LEBOSS standard
+(**v0.1.0-rc**, updated through proposal/0.0.29). It defines and explains
+nothing — it points to the files that do. Where this document and the
+authoritative spec appear to conflict, the spec governs.
+
+- Authoritative standard:
+  [`standards/leboss-standard.md`](../../standards/leboss-standard.md)
+- Full rule register (115 rules):
+  [`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md)
+- Conformance definition:
+  [`standards/conformance.md`](../../standards/conformance.md)
+
+---
+
+## 1. Rule group codes
+
+The register organizes **115 normative rules** across **19 groups**. Rules are
+identified as `LEBOSS-{GROUP}-{n}`. The MUST / MUST NOT / MAY split is 72 / 46 /
+5 *(per [`STATUS.md`](../../STATUS.md))*; the headline figures are 115 rules / 19
+groups / 25 non-conformance conditions.
+
+| Code | Group name | Rules | What it governs |
+|---|---|---:|---|
+| OWN | Ownership | 10 | Who owns primary operational data; derived-data limits |
+| ACC | Access | 5 | Access-grant requirements; explicit authorization before access |
+| ARCH | Architectural | 11 | Reference Model topology; data-boundary enforcement |
+| SEC | Security | 5 | Data separation; least privilege; auditability |
+| CONT | Continuity | 4 | Long-term resilience; ownership transition; succession |
+| SVC | Service Provider | 9 | Stewardship obligations; subprocessor disclosure; no secondary use |
+| SPEC | Specification Boundary | 4 | What LEBOSS does and does not define; no selective override |
+| ENF | Enforcement Responsibility | 4 | Operational enforcement; policy alone is insufficient |
+| REC | Audit as System of Record | 4 | Audit records as authoritative; no irreconcilable state |
+| PORT | Data Portability | 6 | Export completeness; format independence; manifest |
+| MAP | Cross-System Resource Identity & Mapping | 6 | Stable portable identity; cross-system resolvability |
+| DEL | Delegation & Authority Chain | 6 | Scope limits; chain traceability; cascade revocation |
+| VER | Conformance Verification | 6 | Verifiability; observable evidence; no partial-claim misrepresentation |
+| PROT | Protocol Normativity | 5 | Incorporated protocol documents carry normative force |
+| ACTOR | Actor Identity Portability | 6 | Actor references interpretable outside the originating system |
+| GEA | Governing Entity Authenticity | 6 | Governing entity independent of and not controlled by a platform |
+| AUD | Audit Resolution | 6 | Informational-detail floor for audit-record content |
+| DCL | Delegation Chain Lifetime | 6 | Delegation evidence persists as long as the chain is active |
+| REV | Revocation Enforcement Timing | 6 | Revocation effective at the point of enforcement; no cache tolerance |
+| **Total** | **19 groups** | **115** | |
+
+Authoritative source:
+[`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md).
+The full register is the implementer checklist.
+
+> `ACP`, `AGP`, `DPP`, and `IDP` are **protocol-document** rule codes, not
+> register group codes. They appear in non-conformance condition #20.
+> *(See [`standards/conformance.md` §4 item 20](../../standards/conformance.md).)*
+
+---
+
+## 2. The six LEBOSS Elements
+
+Authoritative source:
+[`standards/leboss-standard.md` §5.2](../../standards/leboss-standard.md) and
+[`glossary/terms.md`](../../glossary/terms.md). Implementations may use any
+internal naming; the spatial names are a communication vocabulary, not a
+conformance requirement.
+*(See [`standards/leboss-standard.md` §5.1](../../standards/leboss-standard.md).)*
+
+| # | Name | One-line role | Data boundary | Key rules |
+|---|---|---|---|---|
+| 0 | Universe | Root owner: the person, family, or registered legal entity that owns the enterprise and holds ultimate authority over all data-access decisions | All other elements | OWN-1, OWN-2, ARCH-2 |
+| 1 | Galaxy | An individual brand, business line, or operating company owned by a Universe; has its own branding, teams, settings, and data boundary | Stars, Planets, Moons within it | ARCH-3 |
+| 2 | Star | The customer-facing interface (website, app, booking portal, kiosk); cannot function without a Planet | User-facing experience | ARCH-4, ARCH-5 |
+| 3 | Planet | The backend service powering a Star: business logic, persistence, operational functionality; holds primary operational data; must serve at least one Star | Business logic, data persistence | ARCH-4, ARCH-6, ARCH-7 |
+| 4 | Moon | A company-owned, company-operated internal capability within a Galaxy's data boundary (natural-satellite analogy) | Company-owned resources | ARCH-8 |
+| 5 | Satellite | A connection to a third-party platform operated outside the business's control; greatest sovereignty risk; must be explicitly authorized and audited | Third-party connection boundary | ACC-5, ARCH-9, ARCH-10, ARCH-11 |
+
+Hierarchy: `Universe → Galaxy → Star ↔ Planet → (Moon | Satellite)`. The Star
+and Planet are bidirectionally dependent: each is required for the other to have
+purpose.
+*(See [`standards/leboss-standard.md` §5.3–§5.4](../../standards/leboss-standard.md).)*
+
+---
+
+## 3. Conformance tiers
+
+Two — and only two — defined conformance terms.
+*(See [`standards/conformance.md` §1.0](../../standards/conformance.md) and
+[`glossary/terms.md`](../../glossary/terms.md).)*
+
+- **LEBOSS-aligned** — structural conformance. The system preserves the LEBOSS
+  ownership hierarchy, data boundaries, dependency rules, and access-control
+  relationships of the Reference Model, regardless of internal naming. Does not
+  require satisfaction of all MUST-level protocol requirements.
+- **LEBOSS-compliant** — normative conformance. The system satisfies all
+  MUST-level requirements in `standards/conformance.md` §3 and exhibits none of
+  the §4 conditions. Every LEBOSS-compliant system is also LEBOSS-aligned.
+
+**"LEBOSS-conformant"** is not a defined LEBOSS conformance term and must not be
+used as a conformance claim.
+*(See [`standards/conformance.md` §1.0](../../standards/conformance.md) and
+[`glossary/terms.md`](../../glossary/terms.md).)*
+
+---
+
+## 4. Governance objects
+
+Three governance objects underpin LEBOSS-compliant systems.
+*(See [`standards/leboss-standard.md` §11](../../standards/leboss-standard.md).)*
+
+| Object | Purpose | Authoritative source |
+|---|---|---|
+| Access Grant | Records explicit, scoped authorization for a party to access primary operational data | [`standards/objects/access-grant.md`](../../standards/objects/access-grant.md) |
+| Integration Descriptor | Records authorization of an external integration (Satellite) to receive data; five-state lifecycle | [`standards/objects/integration-descriptor.md`](../../standards/objects/integration-descriptor.md) |
+| Audit Record | Records governed events for auditability; immutable; 36-month minimum retention | [`standards/objects/audit-record.md`](../../standards/objects/audit-record.md) |
+
+---
+
+## 5. Non-conformance conditions (index)
+
+25 conditions. A system exhibiting any of these must not claim LEBOSS-compliant.
+Full text:
+[`standards/conformance.md` §4](../../standards/conformance.md).
+
+| # | Name | Governing rules |
+|---|---|---|
+| 1 | Unauthorized access | ACC-1, ACC-4 |
+| 2 | Audit bypass | SEC-3, SVC-3 |
+| 3 | Incomplete exports | PORT-1, PORT-2 |
+| 4 | Export restriction | OWN-3, SVC-1 |
+| 5 | Data retention after exit | SVC-1, OWN-8 |
+| 6 | Secondary use without consent | SVC-6, OWN-7 |
+| 7 | Rule redefinition | SPEC-3 |
+| 8 | Unenforced requirements | ENF-1, ENF-2 |
+| 9 | Irreconcilable state | REC-2 |
+| 10 | Non-reconstructable export | PORT-4 |
+| 11 | Proprietary format dependency | PORT-5 |
+| 12 | Identity-breaking import | MAP-4 |
+| 13 | Proprietary identity dependency | MAP-6 |
+| 14 | Unbounded delegation | DEL-1 |
+| 15 | Untraceable authority chain | DEL-3, DEL-4, DEL-5 |
+| 16 | False compliance claim | VER-1, VER-3 |
+| 17 | Unverifiable conformance | VER-2, VER-4, VER-5, VER-6 |
+| 18 | Functionally incomplete export | OWN-10, PORT-1 |
+| 19 | Ungoverned infrastructure access | SVC-8, SVC-9 |
+| 20 | Protocol-only compliance | PROT-1, PROT-2, PROT-3 (+ AGP, IDP, ACP, DPP) |
+| 21 | Opaque actor identity | ACTOR-2, ACTOR-4 |
+| 22 | Platform-dependent ownership | GEA-2, GEA-3, GEA-5 |
+| 23 | Insufficient audit resolution | AUD-3, AUD-5, AUD-6 |
+| 24 | Unverifiable delegation chain lifetime | DCL-2, DCL-4, DCL-6 |
+| 25 | Deferred revocation enforcement | REV-1, REV-3, REV-5 |
+
+---
+
+## 6. Incorporated protocol documents
+
+Four protocol documents carry normative force equal to the register.
+*(See [`standards/leboss-standard.md` §20](../../standards/leboss-standard.md);
+LEBOSS-PROT-1.)*
+
+| Document | Rules | What it operationalizes |
+|---|---|---|
+| [`leboss-access-grant-protocol.md`](../../standards/leboss-access-grant-protocol.md) | AGP-1 – AGP-17 | Grant issuance, validation, immediate revocation, expiration |
+| [`leboss-integration-protocol.md`](../../standards/leboss-integration-protocol.md) | IDP-1 – IDP-26 | Integration Descriptor five-state lifecycle; cascade suspension on revocation |
+| [`leboss-audit-protocol.md`](../../standards/leboss-audit-protocol.md) | ACP-1 – ACP-24 | Event capture, 36-month retention, immutability, integrity verification |
+| [`leboss-data-portability-protocol.md`](../../standards/leboss-data-portability-protocol.md) | DPP-1 – DPP-28 | Export authority, completeness, manifest, format neutrality, export audit |
+
+---
+
+## 7. Versioning scheme
+
+`X.Y.Z` with LEBOSS-specific meaning.
+*(See [`STATUS.md`](../../STATUS.md) and
+[`governance/governance.md`](../../governance/governance.md).)*
+
+| Position | Label | Meaning |
+|---|---|---|
+| Z (rightmost) | Draft | Working document open for contribution |
+| Y (middle) | Committee Vote | Accepted by committee; open for member ratification |
+| X (leftmost) | Published | Ratified by members; active canonical standard |
+
+Current: **v0.1.0-rc** (proposal 0.0.29) — a structurally complete release
+candidate for the first Committee Vote. The committee is not yet appointed, so a
+vote cannot yet be called. Path to publication:
+`0.0.29 / v0.1.0-rc` → `0.1.0` (Committee Vote) → `1.0.0` (Published canonical).
+
+---
+
+## 8. Authoritative file index
+
+| Subject | File |
+|---|---|
+| Base standard (governing document) | [`standards/leboss-standard.md`](../../standards/leboss-standard.md) |
+| Normative rule register (115 rules) | [`standards/leboss-normative-rules.md`](../../standards/leboss-normative-rules.md) |
+| Conformance (tiers, §3, §4) | [`standards/conformance.md`](../../standards/conformance.md) |
+| Terminology | [`glossary/terms.md`](../../glossary/terms.md) |
+| Mission and philosophy | [`charter/mission.md`](../../charter/mission.md) |
+| Governance process | [`governance/governance.md`](../../governance/governance.md) |
+| Committee roles | [`governance/committee.md`](../../governance/committee.md) |
+| Contribution process | [`CONTRIBUTING.md`](../../CONTRIBUTING.md) |
+| Version and status | [`STATUS.md`](../../STATUS.md) |
+| Implementations registry | [`IMPLEMENTATIONS.md`](../../IMPLEMENTATIONS.md) |
+| Access Grant object | [`standards/objects/access-grant.md`](../../standards/objects/access-grant.md) |
+| Integration Descriptor object | [`standards/objects/integration-descriptor.md`](../../standards/objects/integration-descriptor.md) |
+| Audit Record object | [`standards/objects/audit-record.md`](../../standards/objects/audit-record.md) |
+| Resource Model | [`standards/leboss-resource-model.md`](../../standards/leboss-resource-model.md) |
+| Access Grant Protocol | [`standards/leboss-access-grant-protocol.md`](../../standards/leboss-access-grant-protocol.md) |
+| Integration Descriptor Protocol | [`standards/leboss-integration-protocol.md`](../../standards/leboss-integration-protocol.md) |
+| Audit Record Collection Protocol | [`standards/leboss-audit-protocol.md`](../../standards/leboss-audit-protocol.md) |
+| Data Portability Protocol | [`standards/leboss-data-portability-protocol.md`](../../standards/leboss-data-portability-protocol.md) |
+| Live portal | <https://leboss.status26.com/> |
+
+---
+
+See also: the [tutorial](../tutorials/model-your-first-business.md),
+[how to check conformance](../how-to/check-conformance.md),
+[how to map a Satellite](../how-to/map-a-satellite-conformantly.md), and
+[why the orbital model](../explanation/why-the-orbital-model.md).

--- a/docs/tutorials/model-your-first-business.md
+++ b/docs/tutorials/model-your-first-business.md
@@ -1,0 +1,269 @@
+# Model Your First Business with the LEBOSS Reference Model
+
+This tutorial walks you through the first skill you need to use LEBOSS in
+practice: mapping a real business onto the six elements of the LEBOSS Reference
+Model.
+
+By the end you will have built a complete element map for a hypothetical local
+bakery. The same thinking applies to any local business — a dental practice, a
+landscaping service, a restaurant — once you have done it with this guided
+example.
+
+You will not make any architectural choices. The business is given; your job is
+to observe and map. Every step confirms whether you placed each element
+correctly and explains why.
+
+This tutorial does not require any software. All you need is a way to take
+notes. LEBOSS is a standard, not a tool — there is nothing to install. What you
+are learning is a way of thinking, and the Reference Model is its vocabulary:
+a way to be precise about who owns what and who is responsible for what.
+
+> The Reference Model is defined once, in
+> [`standards/leboss-standard.md` §5](../../standards/leboss-standard.md). This
+> tutorial points into that section; it does not restate it. Where this page
+> and the standard appear to differ, the standard governs.
+
+---
+
+## Meet Sunrise Bakery
+
+Sunrise Bakery is a sole proprietorship owned by Maria Chen. She has been
+operating for four years. Her digital presence looks like this:
+
+- The business is legally registered as **Sunrise Bakery LLC**.
+- She has one brand. There are no sub-brands or second business lines.
+- Customers order through **sunrisebakery.com** — a website with a built-in
+  online ordering form.
+- The website is powered by a backend service her developer built: a small
+  ordering and inventory system running on a VPS the developer manages on her
+  behalf.
+- She uses **Square** for in-person payments at the counter.
+- She has a **Google Business Profile** showing her hours, address, and reviews.
+- Her developer built a custom **analytics module** that lives on the same
+  server as the ordering system and produces weekly reports for Maria.
+- She uses **Mailchimp** to send a weekly newsletter to customers who opted in.
+
+Keep this picture in mind. Every item on that list will map to a LEBOSS element
+by the end of this tutorial.
+
+---
+
+## Step 1 — Identify the Universe
+
+The **Universe** is the root owner: the person, family, or registered legal
+entity that owns the entire enterprise and holds ultimate authority over all
+data-access decisions. It is not a software construct. It is a legal and
+organizational reality.
+*(See [`standards/leboss-standard.md` §5.2, Element 0](../../standards/leboss-standard.md).)*
+
+**Ask:** Who ultimately owns this business, its data, and its assets?
+
+For Sunrise Bakery the answer is unambiguous: **Sunrise Bakery LLC**, the
+registered legal entity owned by Maria Chen.
+
+> Write down: **Universe = Sunrise Bakery LLC**
+
+One Universe. One data-sovereignty anchor. Everything else is owned by — or
+exists in explicitly authorized relationship to — this entity.
+
+---
+
+## Step 2 — Identify the Galaxy (or Galaxies)
+
+A **Galaxy** is an individual brand, business line, or operating company within
+the Universe. A Universe with a single brand has a single Galaxy.
+*(See [`standards/leboss-standard.md` §5.2, Element 1](../../standards/leboss-standard.md).)*
+
+**Ask:** Are there distinct brands, separate DBAs, or separate business lines
+under this Universe? Each distinct venture is a Galaxy.
+
+Maria operates one brand — Sunrise Bakery. There is no catering sub-brand and no
+second shop.
+
+> Write down: **Galaxy = Sunrise Bakery (the brand)**
+
+If Maria later opened a second brand — say, a coffee subscription service — that
+would be a second Galaxy under the same Universe. For now, one Galaxy.
+
+---
+
+## Step 3 — Map each customer-facing interface to a Star
+
+A **Star** is the customer-facing interface: anything the outside world touches
+to interact with the business. Websites, booking portals, ordering apps, and
+kiosks are all Stars.
+*(See [`standards/leboss-standard.md` §5.2, Element 2](../../standards/leboss-standard.md).)*
+
+**Ask:** What does a customer (or external partner) actually interact with?
+
+For Sunrise Bakery:
+
+- **sunrisebakery.com** is a Star. Customers browse, order, and get information
+  here.
+
+The Square point-of-sale terminal is an external service Maria connects to, not
+a Star she owns — we handle it in Step 6. The Google Business Profile is also an
+external platform — Step 6.
+
+> Write down: **Star A = sunrisebakery.com (online ordering website)**
+
+**Rule check:** A customer interface must be supported by at least one backend
+service.
+*(See [`standards/leboss-standard.md` §5.4, dependency rule 2](../../standards/leboss-standard.md).)*
+You have not mapped that backend yet — that is Step 4. Continue.
+
+---
+
+## Step 4 — Map each backend service to a Planet and pair it with its Star
+
+A **Planet** is the backend service that powers a Star. It holds the business
+logic, data persistence, and operational functionality, and it holds the
+business's primary operational data. A Planet must serve at least one Star.
+*(See [`standards/leboss-standard.md` §5.2, Element 3](../../standards/leboss-standard.md).)*
+
+**Ask:** What powers each Star? What system actually stores orders, manages
+inventory, authenticates customers, and does the work?
+
+For Sunrise Bakery, the ordering and inventory system on Maria's
+developer-managed VPS powers sunrisebakery.com.
+
+> Write down: **Planet A = Ordering & Inventory System (powers Star A)**
+
+**Dependency rules satisfied:** Star A now has a Planet, and Planet A serves
+Star A.
+*(See [`standards/leboss-standard.md` §5.4, dependency rules 1 and 2](../../standards/leboss-standard.md).)*
+
+**Ownership note:** The Planet holds Maria's customer records, order history,
+and inventory data. Under LEBOSS this is **primary operational data**, owned by
+the Universe (Sunrise Bakery LLC). The developer who manages the VPS is a
+**service provider**, not the owner of this data.
+*(See [`standards/leboss-standard.md` §6.1 and §7.0](../../standards/leboss-standard.md).)*
+
+---
+
+## Step 5 — Identify company-owned internal capabilities as Moons
+
+A **Moon** is a company-owned, company-operated internal capability — a natural
+satellite — that operates within a single Galaxy's data boundary. The defining
+trait: the business retains full operational control.
+*(See [`standards/leboss-standard.md` §5.2, Element 4](../../standards/leboss-standard.md).)*
+
+**Ask:** Are there internal tools, analytics systems, workflow engines, or
+reporting modules that the business owns and operates itself — running on
+infrastructure it authorizes, not on a third-party platform?
+
+For Sunrise Bakery, the custom analytics module the developer built, running on
+the same server as the ordering system, qualifies. It is company-owned and
+company-operated, and it provides a specialized capability (reporting) without
+depending on an external platform.
+
+> Write down: **Moon A = Custom Analytics Module (company-owned reporting)**
+
+**The distinction that matters:** Maria's developer built and operates this
+module within the business's own boundary. If it were instead a third-party
+analytics SaaS that Maria connected to, it would be a Satellite (Step 6). The
+Moon/Satellite line is about who controls the infrastructure and whose data
+boundary the capability sits inside.
+
+---
+
+## Step 6 — Identify third-party integrations as Satellites
+
+A **Satellite** is an artificial satellite: a connection to a third-party
+platform or external service operated outside the business's direct control.
+Satellites carry the greatest data-sovereignty risk in the model. A Satellite
+must be explicitly authorized before it may receive any data, and the data that
+flows through it must be logged.
+*(See [`standards/leboss-standard.md` §5.2, Element 5](../../standards/leboss-standard.md),
+the access rule LEBOSS-ACC-5, and
+[§5.4, dependency rule 4](../../standards/leboss-standard.md).)*
+
+**Ask:** Which services does the business connect to that someone else operates?
+Third-party platforms, payment processors, social profiles, marketing tools?
+
+For Sunrise Bakery:
+
+- **Square** — payment processing, operated by Square
+- **Google Business Profile** — search listing, operated by Google
+- **Mailchimp** — email marketing, operated by its vendor
+
+> Write down:
+> - **Satellite A = Square (payment processing)**
+> - **Satellite B = Google Business Profile (search/reviews)**
+> - **Satellite C = Mailchimp (email marketing)**
+
+**Sovereignty note:** Each Satellite is a point where Maria's operational data —
+customer contact information, purchase history, the email list — flows to
+infrastructure she does not control. Under LEBOSS, each must be explicitly
+authorized by the governing entity before it receives any data, and the flows
+must be auditable. The how-to guide
+[Map a third-party integration (Satellite)](../how-to/map-a-satellite-conformantly.md)
+walks through the governance objects that make that authorization real.
+
+---
+
+## Check your map against the dependency rules
+
+Before finishing, verify your map satisfies the dependency rules from the
+Reference Model.
+*(See [`standards/leboss-standard.md` §5.4](../../standards/leboss-standard.md).)*
+
+| Dependency rule | Check |
+|---|---|
+| A backend service serves at least one customer interface | Planet A serves Star A. Satisfied. |
+| A customer interface is supported by at least one backend service | Star A is supported by Planet A. Satisfied. |
+| An internal capability operates within one brand entity's data boundary | Moon A is within the Sunrise Bakery Galaxy. Satisfied. |
+| An external integration is explicitly authorized before receiving data | Satellites A, B, and C must be authorized. Noted as a requirement for any real implementation. |
+| A brand entity belongs to exactly one governing entity | The Sunrise Bakery Galaxy belongs to Sunrise Bakery LLC. Satisfied. |
+| A customer interface belongs to exactly one brand entity | Star A belongs to the Sunrise Bakery Galaxy. Satisfied. |
+
+The Satellite row is the only one you cannot mark "satisfied" from the map
+alone. That is expected: authorization is an operational fact, not a structural
+one. On paper you have placed the Satellites correctly; in a built system you
+would also have to grant and log their access. That is precisely the work the
+Satellite how-to guide covers.
+
+---
+
+## What you just built
+
+Here is the completed element map for Sunrise Bakery:
+
+```
+Universe:     Sunrise Bakery LLC
+  Galaxy:     Sunrise Bakery (brand)
+    Star A:   sunrisebakery.com
+    Planet A: Ordering & Inventory System   ← powers Star A
+    Moon A:   Custom Analytics Module        ← company-owned reporting
+    Sat A:    Square                         ← third-party, explicit auth required
+    Sat B:    Google Business Profile        ← third-party, explicit auth required
+    Sat C:    Mailchimp                      ← third-party, explicit auth required
+```
+
+Every item on the original list now has a place. Nothing is ambiguous. Ownership
+is visible.
+
+This is the first thing LEBOSS buys you: clarity. Before you can enforce
+ownership or audit access, you have to be able to *see* the structure. You just
+built that view.
+
+---
+
+## Where to go next
+
+- **Read the Reference Model in full** —
+  [`standards/leboss-standard.md` §5](../../standards/leboss-standard.md),
+  including the §5.1 naming disclaimer (you may use any internal names; the
+  structure is what must match) and the complete §5.4 dependency rules.
+- **Learn what primary operational data is** —
+  [`standards/leboss-standard.md` §6.1](../../standards/leboss-standard.md),
+  which defines the data LEBOSS protects.
+- **Govern a Satellite properly** —
+  [How to map a third-party integration (Satellite)](../how-to/map-a-satellite-conformantly.md).
+- **Look up an element, tier, or rule code** —
+  [Normative structure reference](../reference/normative-structure.md).
+- **Understand why the model is shaped this way** —
+  [Why the orbital model](../explanation/why-the-orbital-model.md) and
+  [`docs/PHILOSOPHY.md`](../PHILOSOPHY.md).
+- **See it visually** — start at <https://leboss.status26.com/> for a walk
+  through the Reference Model.

--- a/examples/launch-copy.md
+++ b/examples/launch-copy.md
@@ -1,0 +1,312 @@
+# LEBOSS Launch Copy
+
+**Status:** v0.1.0-rc
+**Updated Through:** proposal/0.0.29
+
+Reusable launch and outreach copy for LEBOSS — a tweet/X thread, a Show HN post, two
+Reddit variants, and an elevator pitch. Every load-bearing claim traces to the
+standard and the repository. Each piece discloses the three honest gaps plainly: no
+implementations, no appointed committee, no vote yet. This is honest hype — confidence
+from the rule register and the mission, not from invented traction.
+
+> **Facts these draw on (locked):** 115 normative rules · 19 rule groups · 25
+> non-conformance conditions · two conformance tiers (LEBOSS-aligned, LEBOSS-compliant)
+> · CC BY 4.0 · live portal at https://leboss.status26.com/ · v0.1.0-rc, a release
+> candidate for the first Committee Vote. The 0.0.29 proposal closed the last of the
+> five gap areas surfaced by the 0.0.21 boundary stress test (undated).
+
+---
+
+## Headline Milestone
+
+**v0.0.29 — Revocation Enforcement Timing (REV group, rules REV-1 through REV-6).**
+
+This proposal closed the last remaining enforcement gap surfaced by the 0.0.21
+boundary stress test: the cached-authorization-window gap, where cached access grants
+could persist beyond revocation. With REV-1 through REV-6 in place, deferred
+revocation is now a named non-conformance condition. That closes all five gap areas
+from the stress test. Result: v0.1.0-rc is structurally complete and ready for the
+first Committee Vote.
+
+---
+
+## 1. Tweet / X Thread (5 posts)
+
+**Post 1 — Hook (the data-ownership problem)**
+
+When a local business switches software platforms, it often discovers the hard way:
+the data it generated — customers, history, revenue records — was never really its
+own. Portability was a vendor feature. Access grants were invisible. The audit trail
+was the vendor's, not yours.
+
+This is not a policy failure. It is structural. And it needs a structural fix.
+
+**Post 2 — The shift LEBOSS proposes**
+
+LEBOSS is an open governance standard that defines data ownership architecturally —
+not contractually, not jurisdictionally.
+
+The core proposal: build a six-element reference model (Universe → Galaxy → Star ↔
+Planet → Moon / Satellite) into the architecture of every local-business system, so
+ownership is traceable at every level from the root owner outward.
+
+https://leboss.status26.com/
+
+**Post 3 — What's concretely real**
+
+What exists today:
+
+- 115 normative rules across 19 groups — each coded and traceable to source
+- 25 named non-conformance conditions mapped to specific rule IDs
+- A two-tier conformance model: LEBOSS-aligned (structural) and LEBOSS-compliant (full
+  normative)
+- Three live presentation decks at leboss.status26.com
+- CC BY 4.0 license — freely adoptable
+- A 29-proposal change history, 0.0.1 through 0.0.29
+
+**Post 4 — The headline milestone**
+
+The latest proposal (0.0.29) closed the last enforcement gap: revocation enforcement
+timing. If an access grant is revoked, a system may not keep serving cached
+authorizations past the revocation. That gap is now a named non-conformance condition
+(REV-1 through REV-6).
+
+With that, v0.1.0-rc is structurally complete. Every governance layer is in place. The
+spec is ready for its first Committee Vote.
+
+**Post 5 — Honest call to action**
+
+Full transparency: this is a release candidate. Zero implementations yet. The
+committee is not yet appointed. v0.1.0 has not been voted on.
+
+What is open right now: reading the standard, implementing against it, and nominating
+yourself to the forming committee.
+
+If you build for local businesses and care about who actually owns the data — this is
+the conversation to join.
+
+github.com/jwogrady/leboss | leboss.status26.com | CC BY 4.0
+
+---
+
+## 2. Show HN Post
+
+**Title:**
+Show HN: LEBOSS — an open governance standard for local-business data ownership (v0.1.0-rc, CC BY 4.0)
+
+**Body:**
+
+LEBOSS (Local Entrepreneur Business Operating System Standards) is an open
+specification — not a library, not an SDK, not a SaaS product. You cannot npm install
+it. The "install step" is reading the standard.
+
+What it specifies: a governance layer for local-business data systems. The core
+problem it addresses is structural: in most local-business software stacks, the
+platform controls the data, not the business. Switching vendors loses history.
+Integrations accumulate undeclared access. There is no inspectable audit trail. LEBOSS
+treats this as an architectural problem, not a contract problem.
+
+What it actually contains:
+
+- A six-element reference model (Universe → Galaxy → Star ↔ Planet → Moon / Satellite)
+  that maps the entire enterprise ownership topology from the root owner outward.
+- 115 normative rules across 19 groups, each cited to a source section. 25 named
+  non-conformance conditions, each mapped to specific rule IDs.
+- Three governance objects the owner holds — Access Grant, Integration Descriptor,
+  Audit Record — not features a vendor offers.
+- Two conformance tiers: LEBOSS-aligned (preserve hierarchy and access relationships)
+  and LEBOSS-compliant (satisfy every MUST-level requirement in conformance.md).
+  Conformance is self-declared; no third-party certification exists in this version.
+- A live three-deck Slidev portal: leboss.status26.com
+- CC BY 4.0 license.
+
+What it honestly is not yet:
+
+- Ratified: this is a release candidate for the first Committee Vote. The committee is
+  not yet appointed. v0.1.0 has not been voted on.
+- Implemented: IMPLEMENTATIONS.md is empty. No known adopters.
+- Certified: conformance is self-declared. No audit program exists.
+- Finished: until v1.0.0, any rule can change.
+
+The latest proposal (0.0.29) closed the last enforcement gap from the 0.0.21 boundary
+stress test — revocation enforcement timing. That completes the 0.0.21–0.0.29
+gap-closure series and resolves the five gap areas the stress test surfaced. All
+governance layers are now in place.
+
+The committee nomination process is open. If you work in local-business infrastructure
+and this problem space is familiar, the forming committee needs people with
+implementation experience.
+
+Repo: github.com/jwogrady/leboss
+Portal: leboss.status26.com
+Standard: standards/leboss-standard.md
+Conformance: standards/conformance.md
+
+---
+
+## 3. Reddit Post — r/smallbusiness framing
+
+**Title:**
+I wrote an open standard for local business data ownership — 115 rules, free to use (CC BY 4.0), looking for feedback
+
+**Body:**
+
+Background: a recurring problem I kept running into — when a local business switches
+platforms, they often realize their data was never really theirs. Customer history,
+audit trails, integrations: all locked inside the vendor's infrastructure. Portability
+was a feature the vendor could deprecate. Access grants were invisible. There was no
+way to say "this integration is authorized for these specific data scopes, expiring on
+this date, revocable on this timeline" — because there was no shared model for what
+the data footprint even was.
+
+That felt like a structural problem. So I wrote a structural answer.
+
+LEBOSS (Local Entrepreneur Business Operating System Standards) is an open governance
+specification for local-business data systems. The central idea: data ownership should
+be architectural, not contractual. Built into how the system is structured, not
+dependent on what the vendor agrees to in the ToS.
+
+What it defines:
+
+- A six-element ownership hierarchy: Universe (the root owner — you, the business
+  owner) → Galaxy (individual brand or business line) → Star (customer-facing
+  interface) ↔ Planet (backend service) → Moon (internal module you own) / Satellite
+  (third-party integration). Every part of your data footprint has a defined owner and
+  an explicit authorization model.
+- 115 normative rules across 19 groups, covering ownership, access control,
+  delegation, audit, portability, revocation timing, and more.
+- Three governance objects you hold, not your vendor: Access Grant, Integration
+  Descriptor, Audit Record.
+- A clear portability requirement: a compliant system must be able to export all
+  primary operational data in a documented, non-proprietary format complete enough to
+  reconstruct the governed environment without relying on the exporting vendor.
+
+What it honestly is not:
+
+- Software. There is no app, SDK, or package.
+- Adopted yet. Zero implementations registered.
+- Ratified. This is a release candidate. The committee is forming; the first formal
+  vote has not happened.
+- A legal compliance tool. It does not replace GDPR, CCPA, or a data-protection
+  attorney.
+
+It is CC BY 4.0 — free to read, use, implement against, and build on. There is a live
+presentation portal at leboss.status26.com if you want a more visual walkthrough.
+
+I am looking for: feedback from business owners who have run into this problem,
+developers who build local-business software, and anyone who has tried to do a vendor
+migration and discovered what they actually owned.
+
+If this is a problem you have lived, I'd like to know if this framing resonates — and
+what is missing.
+
+Repo: github.com/jwogrady/leboss
+
+---
+
+## 4. Reddit Post — r/programming framing (alternate)
+
+**Title:**
+I wrote a governance standard for local-business data systems: 115 normative rules, two conformance tiers, open for committee formation (v0.1.0-rc, CC BY 4.0)
+
+**Body:**
+
+LEBOSS is an open specification — think W3C or IETF register energy, not a startup
+product launch. It is a governance standard for local-business data systems. The
+"getting started" step is reading the standard, not running an install command.
+
+The problem it addresses: local-business SaaS stacks are structurally designed such
+that the platform, not the business owner, controls the data. This is not a bug in
+individual products — it is the business model (lock-in through low portability).
+LEBOSS proposes a structural fix: define ownership architecturally, with a six-element
+reference model and a flat normative rule register.
+
+Technical specifics:
+
+- 115 normative rules across 19 rule groups (OWN, ACC, ARCH, SEC, CONT, SVC, SPEC, ENF,
+  REC, PORT, MAP, DEL, VER, PROT, ACTOR, GEA, AUD, DCL, REV). Each rule is coded
+  LEBOSS-{GROUP}-{n} and cites its source section.
+- 25 named non-conformance conditions in a separate conformance document, each mapped
+  to specific rule IDs.
+- RFC 2119 discipline: MUST / MUST NOT / MAY confined to standards/ documents.
+- Two conformance tiers: LEBOSS-aligned (preserve hierarchy and access relationships)
+  and LEBOSS-compliant (satisfy all MUST-level requirements). Conformance is
+  self-declared this version.
+- Six-element reference model: Universe → Galaxy → Star ↔ Planet → Moon / Satellite.
+  Owner-to-system authority flows from the root (Universe = the business owner)
+  outward.
+- Three governance objects: Access Grant, Integration Descriptor, Audit Record.
+- Five foundation principles: Clarity, Modularity, Security, Legacy and Continuity,
+  Extensibility.
+- A written proposal lifecycle (PR → Draft → Committee Vote → Published) with 14-day
+  minimum periods, a PR template, and 29 proposals in the change history.
+- CC BY 4.0 license, live Slidev portal at leboss.status26.com.
+
+Current state (honest):
+
+- v0.1.0-rc — release candidate for first Committee Vote (v0.1.0)
+- Committee: not yet appointed. Nomination is open.
+- Implementations: zero. IMPLEMENTATIONS.md is empty.
+- CI/CD: no GitHub Actions (no `.github/` directory). Netlify deploy is the only build
+  verification.
+- Conformance: self-declared. No certification program.
+
+The latest proposal (0.0.29) closed the last enforcement gap from the 0.0.21 boundary
+stress test: the cached-authorization-window gap — access grants that persist past
+revocation in cached authorization systems. REV-1 through REV-6 make deferred
+revocation a named non-conformance condition, closing the last of the five gap areas
+the stress test surfaced.
+
+Looking for: developers who build local-business stacks and have opinions on whether
+this model maps to real system shapes, people with experience on standards-body
+governance, and committee nominees.
+
+Repo: github.com/jwogrady/leboss
+Standard: standards/leboss-standard.md
+Conformance: standards/conformance.md
+Portal: leboss.status26.com
+
+---
+
+## 5. Elevator Pitch (one paragraph, reusable anywhere)
+
+LEBOSS — Local Entrepreneur Business Operating System Standards — is an open governance
+specification that defines data ownership for local-business software systems
+architecturally, not contractually. It gives businesses, developers, and platform
+builders a shared vocabulary: a six-element reference model (Universe down to
+Satellite) that maps the entire enterprise ownership topology, 115 normative rules
+across 19 groups covering ownership, access, audit, portability, and revocation, and a
+two-tier conformance model backed by 25 named non-conformance conditions. The current
+version is v0.1.0-rc — a structurally complete release candidate, CC BY 4.0, with a
+live portal at leboss.status26.com. Zero implementations yet; the forming committee is
+open for nominations. The invitation is to read it, implement against it, and help
+shape the first ratified version.
+
+---
+
+## Search Phrases (organic discovery)
+
+Grounded in the repo's own problem framing — the terms a builder or local-business
+owner would actually search for:
+
+- local business data ownership
+- local business data governance standard
+- open governance standard for local business
+- data sovereignty for small business
+- owner-first data architecture
+- business data portability standard
+- LEBOSS standard
+
+---
+
+## Honesty Checklist (applied to all copy above)
+
+- **Stated in every piece:** zero implementations, committee not yet appointed, v0.1.0
+  not voted, conformance self-declared.
+- **Never claimed:** adopters, user counts, certification, an existing committee, an
+  SDK/API/package, specified data import (only export is normative).
+- **Numbers:** headline is 115 rules / 19 groups / 25 non-conformance conditions.
+- **Stress test:** five gap areas (from seven scenarios across eight attack surfaces),
+  undated.
+- **Terminology:** only LEBOSS-aligned and LEBOSS-compliant used; "LEBOSS-conformant"
+  is not a defined term and does not appear.


### PR DESCRIPTION
## Summary

A multi-persona documentation pass over the public-facing surface. The substance was audited first (see the review snapshot from PR #39); this PR sells it honestly.

**Centerpiece — `README.md` rewrite** (+206/−105):
- **Badge fixes** — `license-MIT` → **CC BY 4.0** (the actual license); `pre-v0.1.0`/`draft` → **v0.1.0-rc / release candidate** (matches every other doc).
- Reference-model and governance-lifecycle Mermaid diagrams (Moon/Satellite shown as associations, not ownership children).
- Three getting-started paths (read the spec · run the decks · implement against it), positioning, and honest trust/maturity signals.

**New companion docs:**
- `docs/PHILOSOPHY.md` — doctrine grounded in `charter/mission.md` (no invented principles).
- `docs/` Diátaxis tree — tutorial (bakery walkthrough), two how-tos (conformance check, Satellite mapping), reference (19 groups / 25 conditions index), explanation (why the orbital model).
- `CHANGELOG.md` — Keep-a-Changelog log complementing `RELEASES.md`.
- `examples/launch-copy.md` — launch copy, constrained to verified claims.

## Honest-hype enforcement

A dedicated fact-check pass caught and corrected real overclaims before they shipped: git tags stop at **v0.0.11** (not v0.0.12), the 0.0.21 stress test surfaced **five gap areas** (not seven), a fabricated date was removed, and no adoption/ratification is implied anywhere (zero implementations and the unappointed committee are stated plainly).

## Notes

- Scope is the whole docs surface, not a diff — this is a standalone glow-up.
- 14 follow-up work items from the docit Issue Council are filed separately as `proposed`-labeled issues.
- All commits carry no AI attribution, per the repo's `CLAUDE.md`/`AGENTS.md`.