### PR TITLE
Backlog fixes: CI, committee, security headers, a11y, docs (stacked)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Slidev presentation portal dependencies
+  - package-ecosystem: npm
+    directory: /presentations/slidev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+
+  # GitHub Actions used by CI
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+# Build verification + spec content-integrity checks on every pull request
+# and on pushes to master. See scripts/check-spec-integrity.sh for the
+# invariants this guards (115 rules / 19 groups / resolvable conformance refs).
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+# Least privilege: this workflow only needs to read the repository.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  spec-integrity:
+    name: Spec integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check spec integrity
+        run: bash scripts/check-spec-integrity.sh
+
+  build-decks:
+    name: Build presentation decks
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: presentations/slidev
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: presentations/slidev/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Build all decks
+        run: npm run build:all

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+title: "LEBOSS — Local Entrepreneur Business Operating System Standards"
+message: "If you reference or build against this standard, please cite it using these metadata."
+type: dataset
+authors:
+  - name: "LEBOSS Contributors"
+repository-code: "https://github.com/jwogrady/leboss"
+url: "https://leboss.status26.com/"
+abstract: >-
+  LEBOSS is an open governance standard defining data ownership, access control,
+  delegation, enforcement, audit, portability, identity, and revocation for local
+  business data systems. It is a release candidate (v0.1.0-rc) ahead of the first
+  Committee Vote.
+keywords:
+  - data-ownership
+  - data-sovereignty
+  - open-standard
+  - governance
+  - data-portability
+  - conformance
+license: CC-BY-4.0
+version: v0.1.0-rc

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -6,22 +6,39 @@ This document tracks systems implementing or aligning with the LEBOSS specificat
 
 ## Implementations
 
-| Project        | Description | Status | LEBOSS Version |
-|----------------|-------------|--------|----------------|
-| *(none yet)*   | -           | -      | -              |
+| Project        | Description | Maturity | Conformance Level | LEBOSS Version |
+|----------------|-------------|----------|-------------------|----------------|
+| *(none yet)*   | -           | -        | -                 | -              |
+
+No implementations are registered yet. The first entry here will be a genuine first.
 
 ---
 
 ## How to Register an Implementation
 
-If you are building a system that implements the LEBOSS standard, open a pull request adding your project to the table above.
+If you are building a system that implements the LEBOSS standard, open a pull request adding a row to the table above.
 
-Include:
+Include each field:
 
-- **Project name** — the name of your project or product
-- **Description** — one sentence describing what it does and how it implements LEBOSS
-- **Status** — one of: `in-development`, `alpha`, `beta`, `production`
-- **LEBOSS Version** — the specification version your implementation targets (e.g., `v0.1.0`)
+- **Project** — the name of your project or product, ideally linked to its repository or site.
+- **Description** — one sentence on what it does and how it implements LEBOSS.
+- **Maturity** — release stage: one of `in-development`, `alpha`, `beta`, `production`.
+- **Conformance Level** — your self-declared level against the standard:
+  - `in-development` — building toward conformance; not yet claiming a level.
+  - `LEBOSS-aligned` — preserves the ownership hierarchy and element boundaries.
+  - `LEBOSS-compliant` — satisfies all MUST-level requirements.
+
+  See [standards/conformance.md](standards/conformance.md) for the exact definitions of the two tiers. ("Conformant" is **not** a defined term — use *aligned* or *compliant*.)
+- **LEBOSS Version** — the specification version your implementation targets (e.g., `v0.1.0-rc`).
+
+### Conformance is self-declared
+
+There is no third-party certification or conformance authority in this version. A
+listed level is the maintainer's own claim. That claim must be **supportable by
+observable system behavior** (per the Conformance Verification rules,
+LEBOSS-VER-2 / VER-4 / VER-6) — a reviewer should be able to confirm it from how
+the system actually behaves, not from the label alone. Do not list a conformance
+level you cannot substantiate.
 
 ---
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -48,8 +48,8 @@ A `1.0.0` or higher version marks a Published standard:
 
 Specification versions are tracked through:
 
-1. **Git tags** — each release is tagged `vX.Y.Z` on the `master` branch
-2. **Proposal directories** — each draft increment has a corresponding `proposals/X.Y.Z/proposal.md` documenting what changed and why
+1. **Git tags** — releases through `v0.0.11` are tagged `vX.Y.Z` on the `master` branch. Tagging lapsed after `v0.0.11`; versions `0.0.12`–`0.0.29` are not yet tagged (backfill is tracked in the issue tracker).
+2. **Proposal directories** — each draft increment has a corresponding `proposals/X.Y.Z/proposal.md` documenting what changed and why. This is the authoritative per-version record for every draft, tagged or not.
 
 ### Draft Releases
 
@@ -68,7 +68,7 @@ Specification versions are tracked through:
 | 0.0.9 | [`v0.0.9`](https://github.com/jwogrady/leboss/releases/tag/v0.0.9) | [proposals/0.0.9](proposals/0.0.9/proposal.md) | Specification Stabilization |
 | 0.0.10 | [`v0.0.10`](https://github.com/jwogrady/leboss/releases/tag/v0.0.10) | [proposals/0.0.10](proposals/0.0.10/proposal.md) | Repository Normalization |
 | 0.0.11 | [`v0.0.11`](https://github.com/jwogrady/leboss/releases/tag/v0.0.11) | [proposals/0.0.11](proposals/0.0.11/proposal.md) | Canonical multi-deck presentation system |
-| 0.0.12 | [`v0.0.12`](https://github.com/jwogrady/leboss/releases/tag/v0.0.12) | [proposals/0.0.12](proposals/0.0.12/proposal.md) | Terminology stabilization — conformance tiers, missing glossary entries, element name alignment |
+| 0.0.12 | *(untagged)* | [proposals/0.0.12](proposals/0.0.12/proposal.md) | Terminology stabilization — conformance tiers, missing glossary entries, element name alignment |
 
 #### Governance Boundary and Enforcement Series (0.0.13–0.0.20)
 
@@ -114,7 +114,9 @@ git tag -a v0.1.0 -m "LEBOSS 0.1.0 — first Committee Vote candidate"
 git push origin v0.1.0
 ```
 
-Each tag marks the state of the specification at that version. The full specification at any past version is recoverable by checking out the corresponding tag.
+Each tag marks the state of the specification at that version. The full specification at any tagged version is recoverable by checking out the corresponding tag.
+
+> **Current tag state:** tags exist for `v0.0.1`–`v0.0.11`. Tagging lapsed for `0.0.12`–`0.0.29`; those versions are recoverable through their merge commits and `proposals/` directories. Backfilling the missing tags is planned so the convention above holds for every version going forward.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,62 @@
+# LEBOSS Roadmap
+
+**Status:** informational — planning, not normative
+**Current version:** v0.1.0-rc (proposal/0.0.29)
+
+This document records intended direction. It is not part of the normative
+specification and introduces no requirements. Anything that would change the
+standard itself proceeds through the proposal workflow in
+[governance/governance.md](governance/governance.md).
+
+---
+
+## Toward the first Committee Vote (v0.1.0)
+
+- Constitute the committee so a Committee Vote can be called (see
+  [governance/committee.md](governance/committee.md)).
+- Hold the first Committee Vote on the v0.1.0 candidate.
+
+## Toward a Published standard (v1.0.0)
+
+The gap between a *readable* specification and *machine-checkable* conformance is
+the main body of post-v0.1.0 work.
+
+### Machine-readable schemas
+
+The three governance objects — Access Grant, Integration Descriptor, and Audit
+Record — are currently defined in prose. Publishing machine-readable schemas
+(for example JSON Schema) for each would let implementers validate object shape
+mechanically.
+
+- Scope: one schema per governance object, derived from the existing object
+  definitions; no new requirements.
+- Where a schema would impose a normative constraint, it must be introduced
+  through a proposal, not added as a side artifact.
+- Status: **not started.** No schemas exist today.
+
+### Conformance test vectors
+
+A starter set of conformance test vectors — concrete example inputs paired with
+expected aligned/compliant verdicts — would turn the 25 non-conformance
+conditions in [standards/conformance.md](standards/conformance.md) from prose
+checks into runnable fixtures.
+
+- Scope: a representative vector for each conformance tier and for the most
+  commonly triggered non-conformance conditions.
+- This subsumes the idea of a reference implementation: test vectors are the
+  smaller, more durable artifact and do not require endorsing any one codebase.
+- Status: **not started.** No test vectors exist today.
+
+### Import / round-trip portability
+
+Only data *export* is normative today; import and round-trip portability are
+explicitly deferred. Specifying them is standard-content work and must be opened
+as a proposal.
+
+---
+
+## Not promises
+
+Everything above is intended direction, not a commitment or a schedule. Items
+land only as proposals are accepted through the governance process. Nothing here
+should be read as already implemented.

--- a/governance/committee.md
+++ b/governance/committee.md
@@ -98,13 +98,51 @@ The committee will hold public discussion periods for all Drafts and will seek t
 
 ## Current Committee
 
+The initial committee is constituted by the founding Maintainer (the bootstrap
+permitted under *How Maintainers Are Appointed*). Until human Committee Members are
+nominated, the review seats are filled by **designated AI reviewer personas** —
+structured review lenses, each accountable to the Maintainer, that examine every
+Proposal and Draft from a distinct perspective and record their assessment in the
+pull request.
+
 | Role | Name | Affiliation |
 |------|------|-------------|
-| Maintainer | *To be appointed* | — |
-| Committee Member | *Open for nomination* | — |
-| Committee Member | *Open for nomination* | — |
+| Maintainer (Chair) | jwogrady | Status26 |
 
-*Nominations are open. See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to participate.*
+**Maintainer conflict-of-interest disclosure:** the Maintainer is affiliated with
+Status26, which provides software and services to local businesses — a relationship
+directly addressed by this standard (see *Conflict of Interest Policy* above).
+Disclosure does not disqualify; it is recorded here so committee decisions can be
+read with it in view.
+
+### Review seats (AI reviewer personas)
+
+| Seat | Review lens | Primary rule groups |
+|------|-------------|---------------------|
+| Owner Advocate | Protects the business owner's (Universe's) sovereignty and the right to leave | OWN, PORT |
+| Implementer Advocate | Tests whether requirements are buildable and verifiable in real systems | SVC, VER, ARCH |
+| Security & Audit Reviewer | Examines authorization, enforcement, and the audit system of record | SEC, ENF, REC, AUD |
+| Continuity & Portability Reviewer | Examines export completeness, identity portability, and revocation timing | CONT, ACTOR, REV, DCL |
+| Conformance Editor | Guards register/standard coherence, rule numbering, and conformance traceability | SPEC, MAP, PROT, DEL, GEA |
+| Adversarial Reviewer | Stress-tests for gaps and contradictions (continuing the 0.0.21 stress-test practice) | all |
+
+### How the persona committee works
+
+- For each Proposal or Draft, each review seat produces a written assessment in the
+  pull request: **approve**, **request changes**, or **reject**, with rationale tied
+  to its lens and the affected rule groups.
+- These assessments are advisory but part of the public record (see *Transparency*).
+  The human Maintainer is accountable for every decision and holds final merge and
+  tie-breaking authority, exactly as defined in *Roles → Maintainers*.
+- The voting thresholds and minimum periods in
+  [governance/governance.md](governance.md) continue to apply. Persona review
+  operationalizes committee review; it does not replace the member-ratification step,
+  which remains a human process as members are seated.
+- This persona arrangement is an **interim bootstrap**. Human Committee Members are
+  actively sought (see *Community Participation* and [CONTRIBUTING.md](../CONTRIBUTING.md));
+  as they are seated, they take up the review seats above. Any change to this
+  arrangement follows the amendment process in
+  [governance/governance.md](governance.md).
 
 ---
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,10 +10,13 @@
   command = "npm run build:all"
 
 # Defense-in-depth security headers for the public static site.
-# The CSP is a conservative baseline that keeps the Slidev-built decks rendering;
-# 'unsafe-inline' is retained because Vite/Slidev production output includes
-# inline styles and scripts. Tighten toward nonces/hashes once verified on a
-# deploy preview.
+# The CSP is a conservative baseline that keeps the Slidev-built decks rendering.
+# Notes:
+#   - 'unsafe-inline' is retained because Vite/Slidev production output includes
+#     inline styles and scripts.
+#   - fonts.googleapis.com / fonts.gstatic.com are allowed because the seriph
+#     theme loads its web fonts from Google Fonts at runtime.
+# Tighten toward nonces/hashes once verified on a deploy preview.
 [[headers]]
   for = "/*"
   [headers.values]
@@ -21,4 +24,4 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "geolocation=(), microphone=(), camera=()"
-    Content-Security-Policy = "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; object-src 'none'"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; script-src 'self' 'unsafe-inline'; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; object-src 'none'"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,17 @@
 
 [context.deploy-preview]
   command = "npm run build:all"
+
+# Defense-in-depth security headers for the public static site.
+# The CSP is a conservative baseline that keeps the Slidev-built decks rendering;
+# 'unsafe-inline' is retained because Vite/Slidev production output includes
+# inline styles and scripts. Tighten toward nonces/hashes once verified on a
+# deploy preview.
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "SAMEORIGIN"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "geolocation=(), microphone=(), camera=()"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; object-src 'none'"

--- a/presentations/slidev/components/cosmic/CosmicDivider.vue
+++ b/presentations/slidev/components/cosmic/CosmicDivider.vue
@@ -6,8 +6,8 @@
 -->
 <template>
   <div class="cosmic-divider relative w-full h-full flex flex-col items-center justify-center overflow-hidden">
-    <!-- Background orbital rings -->
-    <svg class="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="xMidYMid meet">
+    <!-- Background orbital rings (decorative) -->
+    <svg class="absolute inset-0 w-full h-full pointer-events-none" preserveAspectRatio="xMidYMid meet" aria-hidden="true">
       <circle cx="50%" cy="50%" :r="r1" fill="none" stroke="rgba(255,255,255,0.05)" stroke-width="1" />
       <circle cx="50%" cy="50%" :r="r2" fill="none" stroke="rgba(255,255,255,0.04)" stroke-width="1" />
       <circle cx="50%" cy="50%" :r="r3" fill="none" stroke="rgba(255,255,255,0.03)" stroke-width="1" />

--- a/presentations/slidev/components/cosmic/CosmicSystem.vue
+++ b/presentations/slidev/components/cosmic/CosmicSystem.vue
@@ -38,13 +38,16 @@
   <div
     class="cosmic-system relative flex items-center justify-center"
     :style="{ width: `${width}px`, height: `${height}px` }"
+    role="img"
+    :aria-label="ariaLabel"
   >
-    <!-- Starfield -->
+    <!-- Starfield (decorative) -->
     <svg
       v-if="starfield"
       class="absolute inset-0 pointer-events-none"
       :width="width"
       :height="height"
+      aria-hidden="true"
     >
       <circle
         v-for="star in stars"
@@ -57,11 +60,12 @@
       />
     </svg>
 
-    <!-- Orbit rings -->
+    <!-- Orbit rings (decorative) -->
     <svg
       class="absolute inset-0 pointer-events-none"
       :width="width"
       :height="height"
+      aria-hidden="true"
     >
       <circle
         v-for="orbit in orbits"
@@ -76,12 +80,13 @@
       />
     </svg>
 
-    <!-- Connector lines from center to each node -->
+    <!-- Connector lines from center to each node (decorative) -->
     <svg
       v-if="showConnectors"
       class="absolute inset-0 pointer-events-none"
       :width="width"
       :height="height"
+      aria-hidden="true"
     >
       <line
         v-for="conn in connectorLines"
@@ -176,6 +181,20 @@ const props = withDefaults(defineProps<{
 
 const cx = computed(() => props.width / 2)
 const cy = computed(() => props.height / 2)
+
+// Text alternative describing the orbital diagram for assistive technology.
+const ariaLabel = computed(() => {
+  const center = `${props.centerLabel}${props.centerSub ? ` (${props.centerSub})` : ''} at the center`
+  const layers = props.orbits
+    .map((orbit, oi) => {
+      const nodes = orbit.nodes
+        .map((n) => `${n.label}${n.sub ? ` (${n.sub})` : ''}`)
+        .join(', ')
+      return nodes ? `orbit ${oi + 1}: ${nodes}` : ''
+    })
+    .filter(Boolean)
+  return `LEBOSS orbital diagram. ${[center, ...layers].join('; ')}.`
+})
 
 // Deterministic starfield
 const stars = computed(() => {

--- a/presentations/slidev/public/social-preview.svg
+++ b/presentations/slidev/public/social-preview.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="640" viewBox="0 0 1280 640" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <radialGradient id="bg" cx="68%" cy="42%" r="75%">
+      <stop offset="0%" stop-color="#15213b"/>
+      <stop offset="100%" stop-color="#0a0f1c"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="640" fill="url(#bg)"/>
+
+  <!-- Left: text block -->
+  <text x="90" y="250" fill="#ffffff" font-size="92" font-weight="700" letter-spacing="2">LEBOSS</text>
+  <text x="92" y="312" fill="#9db4d8" font-size="30" font-weight="400">Own your business data — architecturally.</text>
+  <text x="92" y="360" fill="#6b7f9e" font-size="22" font-weight="400">An open governance standard for local business data systems.</text>
+
+  <text x="92" y="470" fill="#cfe0ff" font-size="24" font-weight="600">115 rules &#183; 19 groups &#183; CC BY 4.0 &#183; v0.1.0-rc</text>
+  <text x="92" y="512" fill="#6b7f9e" font-size="22" font-weight="400">leboss.status26.com</text>
+
+  <!-- Right: orbital motif. Center = Universe, ring of six elements. -->
+  <g transform="translate(960,320)" stroke-opacity="0.2">
+    <circle r="120" fill="none" stroke="#ffffff" stroke-width="1"/>
+    <circle r="210" fill="none" stroke="#ffffff" stroke-width="1"/>
+  </g>
+  <g transform="translate(960,320)">
+    <!-- center: Universe -->
+    <circle r="52" fill="#3b82f6" fill-opacity="0.45" stroke="#60a5fa" stroke-width="2"/>
+    <text x="0" y="6" fill="#ffffff" font-size="18" font-weight="700" text-anchor="middle">Universe</text>
+
+    <!-- inner orbit: Galaxy -->
+    <g transform="translate(0,-120)">
+      <circle r="40" fill="#9333ea" fill-opacity="0.45" stroke="#c084fc" stroke-width="2"/>
+      <text x="0" y="5" fill="#ffffff" font-size="15" font-weight="600" text-anchor="middle">Galaxy</text>
+    </g>
+
+    <!-- outer orbit: Star, Planet, Moon, Satellite -->
+    <g transform="translate(149,-149)">
+      <circle r="38" fill="#eab308" fill-opacity="0.45" stroke="#facc15" stroke-width="2"/>
+      <text x="0" y="5" fill="#ffffff" font-size="14" font-weight="600" text-anchor="middle">Star</text>
+    </g>
+    <g transform="translate(210,0)">
+      <circle r="38" fill="#22c55e" fill-opacity="0.45" stroke="#4ade80" stroke-width="2"/>
+      <text x="0" y="5" fill="#ffffff" font-size="14" font-weight="600" text-anchor="middle">Planet</text>
+    </g>
+    <g transform="translate(-149,149)">
+      <circle r="36" fill="#6366f1" fill-opacity="0.45" stroke="#818cf8" stroke-width="2"/>
+      <text x="0" y="5" fill="#ffffff" font-size="14" font-weight="600" text-anchor="middle">Moon</text>
+    </g>
+    <g transform="translate(149,149)">
+      <circle r="36" fill="#ef4444" fill-opacity="0.45" stroke="#f87171" stroke-width="2"/>
+      <text x="0" y="4" fill="#ffffff" font-size="12" font-weight="600" text-anchor="middle">Satellite</text>
+    </g>
+  </g>
+</svg>

--- a/scripts/check-spec-integrity.sh
+++ b/scripts/check-spec-integrity.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# check-spec-integrity.sh — mechanical integrity checks for the LEBOSS standard.
+#
+# Guards the headline invariants the whole project rests on:
+#   1. The rule register defines exactly 115 rules across 19 groups.
+#   2. The 19 groups used by defined rules match the 19 groups declared in the
+#      register's "Rule Numbering" section.
+#   3. Every rule ID referenced by a non-conformance condition in conformance.md
+#      resolves to a rule actually defined somewhere in the normative corpus
+#      (the register or one of the incorporated protocol documents).
+#   4. STATUS.md's stated rule/group counts agree with the register.
+#
+# Exits non-zero on the first failed invariant. No dependencies beyond coreutils.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REGISTER="$ROOT/standards/leboss-normative-rules.md"
+CONFORMANCE="$ROOT/standards/conformance.md"
+STATUS="$ROOT/STATUS.md"
+PROTOCOLS=(
+  "$ROOT/standards/leboss-access-grant-protocol.md"
+  "$ROOT/standards/leboss-integration-protocol.md"
+  "$ROOT/standards/leboss-audit-protocol.md"
+  "$ROOT/standards/leboss-data-portability-protocol.md"
+)
+
+EXPECTED_RULES=115
+EXPECTED_GROUPS=19
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+echo "LEBOSS spec integrity check"
+echo "==========================="
+
+# --- 1. Exactly 115 defined rules in the register -----------------------------
+rule_count="$(grep -cE '^\*\*LEBOSS-[A-Z]+-[0-9]+\*\*' "$REGISTER")"
+[ "$rule_count" -eq "$EXPECTED_RULES" ] \
+  || fail "register defines $rule_count rules, expected $EXPECTED_RULES"
+pass "register defines exactly $EXPECTED_RULES rules"
+
+# --- 2. Exactly 19 defined groups, matching the declared numbering -------------
+defined_groups="$(grep -oE '^\*\*LEBOSS-[A-Z]+-[0-9]+' "$REGISTER" \
+  | sed -E 's/^\*\*LEBOSS-([A-Z]+)-[0-9]+/\1/' | sort -u)"
+defined_group_count="$(printf '%s\n' "$defined_groups" | grep -c .)"
+[ "$defined_group_count" -eq "$EXPECTED_GROUPS" ] \
+  || fail "defined rules span $defined_group_count groups, expected $EXPECTED_GROUPS"
+pass "defined rules span exactly $EXPECTED_GROUPS groups"
+
+# Groups declared in the "Rule Numbering" bullet list (lines like: - `OWN` — ...)
+declared_groups="$(grep -oE '^- `[A-Z]+`' "$REGISTER" \
+  | sed -E 's/^- `([A-Z]+)`/\1/' | sort -u)"
+if [ "$(printf '%s\n' "$declared_groups" | grep -c .)" -ne "$EXPECTED_GROUPS" ]; then
+  fail "Rule Numbering section declares $(printf '%s\n' "$declared_groups" | grep -c .) groups, expected $EXPECTED_GROUPS"
+fi
+if [ "$defined_groups" != "$declared_groups" ]; then
+  echo "defined groups:  $(echo $defined_groups)" >&2
+  echo "declared groups: $(echo $declared_groups)" >&2
+  fail "defined rule groups do not match the declared Rule Numbering list"
+fi
+pass "defined groups match the declared Rule Numbering list"
+
+# --- 3. Build the universe of valid rule IDs (register + protocols) ------------
+valid_ids="$(grep -hoE '^\*\*LEBOSS-[A-Z]+-[0-9]+' "$REGISTER" "${PROTOCOLS[@]}" \
+  | sed -E 's/^\*\*//' | sort -u)"
+
+# Every rule ID referenced in conformance.md must resolve to a defined rule.
+missing=0
+while IFS= read -r ref; do
+  [ -z "$ref" ] && continue
+  if ! printf '%s\n' "$valid_ids" | grep -qxF "$ref"; then
+    echo "  unresolved rule reference in conformance.md: $ref" >&2
+    missing=1
+  fi
+done < <(grep -oE 'LEBOSS-[A-Z]+-[0-9]+' "$CONFORMANCE" | sort -u)
+[ "$missing" -eq 0 ] || fail "conformance.md references rule IDs that are not defined anywhere"
+pass "every rule ID referenced in conformance.md resolves to a defined rule"
+
+# --- 4. STATUS.md counts agree with the register ------------------------------
+grep -qE "\b$EXPECTED_RULES\b normative rules" "$STATUS" \
+  || fail "STATUS.md does not state '$EXPECTED_RULES normative rules'"
+grep -qE "\b$EXPECTED_GROUPS\b rule groups" "$STATUS" \
+  || fail "STATUS.md does not state '$EXPECTED_GROUPS rule groups'"
+pass "STATUS.md counts agree with the register ($EXPECTED_RULES rules / $EXPECTED_GROUPS groups)"
+
+echo "==========================="
+echo "All spec integrity checks passed."


### PR DESCRIPTION
Stacked fixes for the `proposed`-labeled backlog from the docit Issue Council. One PR, one commit per issue.

## Resolved (closes on merge)

- **Closes #41** — CI workflow: `build:all` (Node 22) + a `scripts/check-spec-integrity.sh` content check (asserts 115 rules / 19 declared groups, and that every conformance.md rule ID resolves). _Manual follow-up: mark the check Required in branch protection._
- **Closes #42** — Interim **persona committee** constituted in `governance/committee.md` (founding Maintainer + AI reviewer-persona seats with recorded advisory assessments; human Maintainer remains accountable). Includes the Maintainer's conflict-of-interest disclosure.
- **Closes #43** — RELEASES.md tag claims corrected (tags exist only through `v0.0.11`; dead `v0.0.12` link removed; current-tag-state note added).
- **Closes #45** — Dependabot config for the Slidev npm deps + GitHub Actions.
- **Closes #46** — Accessibility labels on the orbital diagram components (`role=img` + generated description; decorative SVG layers `aria-hidden`).
- **Closes #47** — IMPLEMENTATIONS.md on-ramp: maturity vs. conformance level, aligned/compliant tiers, self-declared note (VER-2/4/6).
- **Closes #49** — `ROADMAP.md` scoping schemas + conformance test vectors (non-normative; standard-content routed to proposals).
- **Closes #52** — `CITATION.cff` (cite-by-version, CC BY 4.0, no DOI).
- **Closes #53** — Security headers in `netlify.toml` (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, baseline CSP). _Verify deck rendering on the deploy preview before tightening the CSP._

## Partial / still open

- **#44 (partial)** — social-preview **SVG source** added under `presentations/slidev/public/`. PNG export, `og:image` wiring, and the GitHub repo social-preview setting remain follow-up (no SVG→PNG tooling here; OG consumers need PNG). Issue stays open.

## Deferred (not in this PR — need their own path)

- **#48** — import / round-trip portability is **standard content** and must go through the proposal → Committee Vote workflow, not a tooling PR.
- **#50** — deck screenshots need an actual capture step.
- **#51** — Slidev 0.49.x → 1.x is a risky major upgrade needing interactive verification.
- **#54** — awesome-list submission is manual research.

## Verification notes

- `scripts/check-spec-integrity.sh` passes locally (115/19, all conformance refs resolve).
- The Vue edits and `build:all` are **not** verified locally (`node_modules` absent here); CI and the Netlify deploy preview on this PR are the verification path.
- No AI attribution in any commit, per the repo's `CLAUDE.md`/`AGENTS.md`.